### PR TITLE
feat: read-only Tipalti REST v2 explorer (0.1.0)

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -17,3 +17,4 @@ config:
 ignores:
   - "node_modules/**"
   - ".local/**"
+  - ".venv/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-05-01
+
+### Added
+
+- tipalti payee list / payee get — read-only Payees verbs (REST v2)
+- tipalti invoice list / invoice get — read-only Invoices verbs
+- tipalti bill list / bill get — read-only Bills verbs
+- tipalti.api package — CLI-agnostic httpx client with OAuth2 client_credentials, on-disk token cache (`$XDG_CACHE_HOME/tipalti/token-<env>.json`, mode 0600), and HTTP-status → AfiError mapping
+- Real tipalti whoami probe — exits 0 with status=unauthenticated when creds missing or 401
+- Markdown render helpers in cli/_output.py (render_record_md, render_list_md, render_kv_md) — agent-friendly default human mode
+- Env vars: TIPALTI_CLIENT_ID, TIPALTI_CLIENT_SECRET, TIPALTI_ENV (sandbox|production), optional TIPALTI_API_BASE / TIPALTI_TOKEN_URL overrides
+- explain entries: auth, payee[/list/get], invoice[/list/get], bill[/list/get]
+
+### Changed
+
+- tipalti whoami no longer a stub; rewrites the v0.0.1 unauthenticated contract into a real probe with the same exit semantics
+- tipalti learn copy expanded to cover the new verbs, env vars, and pagination model
+
 ## [0.0.1] - 2026-05-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to [Claude Code](https://claude.com/claude-code) whe
 
 ## Status
 
-Scaffolded from the AgentCulture sibling pattern at `v0.0.1`. The bootstrap PR (`bootstrap/sibling-pattern`, see `agentculture/tipalti#1`) lands the package, CI, and vendored skills described below. Manual one-time setup after the bootstrap PR merges:
+`v0.1.0` — first real release. Adds read-only verbs over Tipalti REST v2 (Payees, Invoices, Bills), OAuth2 client-credentials auth via env vars, and a real `whoami` probe. Mutations, iFrame URL generation, webhooks, SOAP, tax forms, and KYC are deferred to subsequent releases.
+
+Scaffolded from the AgentCulture sibling pattern. Manual one-time setup (already completed for the v0.0.1 bootstrap PR):
 
 1. Configure **PyPI Trusted Publishing** for `tipalti` ← `agentculture/tipalti`, environment `pypi`, workflow `publish.yml`. Same for **TestPyPI**.
 2. Create GitHub Environments `pypi` and `testpypi` on the repo.
@@ -12,9 +14,25 @@ Scaffolded from the AgentCulture sibling pattern at `v0.0.1`. The bootstrap PR (
 
 ## What this project is
 
-`tipalti` is the CLI for Tipalti Solutions, scaffolded from the AgentCulture sibling pattern (the same shape used by [`steward`](https://github.com/agentculture/steward) and the agent-first CLI tree from [`afi-cli`](https://github.com/agentculture/afi-cli)). v0.0.1 ships only the agent-first affordances (`learn`, `explain`) and an auth-probe stub (`whoami`); domain verbs that exercise the Tipalti API land in subsequent releases.
+`tipalti` is the CLI for Tipalti Solutions, scaffolded from the AgentCulture sibling pattern (the same shape used by [`steward`](https://github.com/agentculture/steward) and the agent-first CLI tree from [`afi-cli`](https://github.com/agentculture/afi-cli)). v0.1.0 ships a read-only explorer over Tipalti REST v2 (Payees, Invoices, Bills) plus the agent-first affordances (`learn`, `explain`, `whoami`); mutations, iFrame URL generation, webhooks, SOAP, tax forms, and KYC land in subsequent releases.
+
+The first resident user of this CLI is an LLM agent. Every verb supports `--json`, default human-mode output is markdown, errors carry machine-readable remediation hints, and one verb invocation = one upstream HTTP request (auth excluded). State lives in env vars; the only persistent file is the bearer-token cache.
 
 The repo is intentionally portable: it assumes nothing about local sibling checkouts. `pyproject.toml`, CI workflows, and skills are pulled from steward over the network at bootstrap time, then committed verbatim (or with the documented token substitutions). `steward doctor . --scope self` enforces this on every PR.
+
+## Auth and environment
+
+Tipalti REST v2 uses OAuth 2.0 client credentials. The CLI reads:
+
+- `TIPALTI_CLIENT_ID` / `TIPALTI_CLIENT_SECRET` — required.
+- `TIPALTI_ENV` — `sandbox` | `production`; default `sandbox`.
+- `TIPALTI_API_BASE` / `TIPALTI_TOKEN_URL` — optional URL overrides.
+
+Bearer tokens are cached at `$XDG_CACHE_HOME/tipalti/token-<env>.json` (file mode `0600`). The cache is a pure performance optimization: delete the file to force re-auth. Rotating the client ID invalidates the cache automatically (the cache record carries a hash of the client ID).
+
+`tipalti whoami` is a probe, not a gate: missing creds and `401` both report `unauthenticated` and exit `0`.
+
+There is one opt-in integration test (`@pytest.mark.integration`) that hits the real sandbox if `TIPALTI_CLIENT_ID/SECRET` and `TIPALTI_ENV=sandbox` are set; it is skipped by default and not run in CI.
 
 ## Project shape
 
@@ -24,18 +42,27 @@ Distributed as **`tipalti`** on PyPI (Trusted Publishing). The Python package is
 tipalti/                    # Python package (pip install tipalti)
 ├── __init__.py             # __version__ via importlib.metadata("tipalti")
 ├── __main__.py             # python -m tipalti
+├── api/                    # CLI-agnostic httpx client over Tipalti REST v2
+│   ├── _env.py             # reads TIPALTI_CLIENT_ID/SECRET/ENV; URL defaults + overrides
+│   ├── auth.py             # OAuth2 client-creds + on-disk token cache
+│   ├── client.py           # TipaltiClient + payees/invoices/bills resource groups
+│   └── errors.py           # HTTP-status → AfiError mapping
 └── cli/
-    ├── __init__.py         # argparse main(); _ArgumentParser, _dispatch
+    ├── __init__.py         # argparse main(); registers all noun groups
     ├── _errors.py          # AfiError + EXIT_USER_ERROR / EXIT_ENV_ERROR
-    ├── _output.py          # emit_result / emit_error / emit_diagnostic
+    ├── _output.py          # emit_result / emit_error + markdown render helpers
+    ├── _listing.py         # shared list/get verb handler
     └── _commands/          # subcommand modules; each has register(sub) + handler
-        ├── learn.py        # `tipalti learn` — agent-affordance prompt
-        ├── explain.py      # `tipalti explain <path>` — markdown catalog lookup
-        └── whoami.py       # `tipalti whoami` — auth probe stub (v0.0.1)
+        ├── learn.py        # `tipalti learn`
+        ├── explain.py      # `tipalti explain <path>`
+        ├── whoami.py       # `tipalti whoami` — real auth probe
+        ├── payee.py        # `tipalti payee {list,get}`
+        ├── invoice.py      # `tipalti invoice {list,get}`
+        └── bill.py         # `tipalti bill {list,get}`
 tipalti/explain/            # markdown catalog driving `explain`
 ├── __init__.py             # resolve() + known_paths()
-└── catalog.py              # ENTRIES dict
-tests/                      # pytest suite (split per-verb)
+└── catalog.py              # ENTRIES dict (root, auth, per-noun, per-verb)
+tests/                      # pytest suite (split per-verb + api unit tests)
 .claude/skills/             # vendored from steward (see "Skills convention")
 .github/workflows/          # tests.yml + publish.yml (OIDC Trusted Publishing)
 pyproject.toml              # version source-of-truth
@@ -51,7 +78,7 @@ CHANGELOG.md                # Keep-a-Changelog
 - **Lint:** `uv run flake8 tipalti tests && uv run black --check . && uv run isort --check .`
 - **Markdown lint:** `markdownlint-cli2 "**/*.md"` (uses repo-local `.markdownlint-cli2.yaml`).
 - **Self-check:** `steward doctor . --scope self`.
-- **Smoke:** `uv run tipalti --version` (expects `0.0.1`) and `uv run python -m tipalti`.
+- **Smoke:** `uv run tipalti --version` (expects `0.1.0`) and `uv run python -m tipalti`.
 - **Build:** `uv build`.
 - **Version bump:** `python3 .claude/skills/version-bump/scripts/bump.py {patch|minor|major}` — updates `pyproject.toml` and prepends a CHANGELOG entry. **Required on every PR** (the `version-check` CI job comments on the PR and fails the run if the version matches main; AgentCulture rule, no exceptions for docs/config-only changes).
 - **Publish:** push to `main` triggers `.github/workflows/publish.yml` → builds with `uv build` → publishes `tipalti` to PyPI via Trusted Publishing (no API tokens). PRs publish a `.dev<run_number>` to TestPyPI for smoke-testing. Fork PRs are skipped (no OIDC context).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # tipalti
 
 CLI for Tipalti Solutions — scaffolded from the AgentCulture sibling pattern.
+Read-only explorer over Tipalti REST v2 (Payees, Invoices, Bills) plus the
+agent-first affordances (`learn`, `explain`, `whoami`).
+
+The first resident user of this CLI is an LLM agent. Every verb supports
+`--json`, default human-mode output is markdown, errors carry
+machine-readable remediation hints, and one verb invocation = one upstream
+HTTP request.
 
 ## Install
 
@@ -10,22 +17,48 @@ uv tool install tipalti
 pipx install tipalti
 ```
 
-## Quickstart
+## Quickstart — agent-first affordances
 
 ```bash
-tipalti --version           # 0.0.1
+tipalti --version           # 0.1.0
 tipalti learn               # structured self-teaching prompt for agents
 tipalti learn --json        # machine-readable form
 tipalti explain tipalti     # root markdown doc
-tipalti explain whoami      # docs for the whoami verb
-tipalti whoami              # auth probe (v0.0.1: always "unauthenticated")
+tipalti explain auth        # env-var setup
+tipalti explain payee       # docs for the payee noun group
 ```
+
+## Quickstart — Tipalti REST v2 (read-only)
+
+```bash
+export TIPALTI_CLIENT_ID=...
+export TIPALTI_CLIENT_SECRET=...
+export TIPALTI_ENV=sandbox        # or production (default: sandbox)
+
+tipalti whoami                                       # markdown principal block
+tipalti whoami --json                                # JSON envelope
+
+tipalti payee list --limit 25                        # markdown table
+tipalti payee list --filter "status eq 'Active'"     # raw $filter passthrough
+tipalti payee list --json --cursor <token>           # paginate by cursor
+tipalti payee get <id>                               # markdown record
+tipalti payee get <id> --json                        # raw API record
+
+tipalti invoice list --limit 25
+tipalti invoice get <id>
+tipalti bill list --limit 25
+tipalti bill get <id>
+```
+
+Bearer tokens are cached at `$XDG_CACHE_HOME/tipalti/token-<env>.json`
+(file mode `0600`). Delete the file to force re-auth.
 
 ## Status
 
-Pre-1.0. v0.0.1 ships only the agent-first affordances (`learn`, `explain`)
-and an auth-probe stub (`whoami`). Domain verbs that exercise the Tipalti
-API land in later releases.
+Pre-1.0. v0.1.0 ships read-only verbs over Tipalti REST v2's Payees,
+Invoices, and Bills resources, plus the agent-first affordances and a
+real `whoami` probe. Mutations, iFrame URL generation, webhooks, SOAP,
+tax forms, and KYC land in later releases.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tipalti"
-version = "0.0.1"
+version = "0.1.0"
 description = "Tipalti — CLI for Tipalti Solutions."
 readme = "README.md"
 license = "MIT"
@@ -12,6 +12,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Topic :: Software Development",
     "Intended Audience :: Developers",
+]
+dependencies = [
+    "httpx>=0.27",
 ]
 
 [project.urls]
@@ -37,6 +40,7 @@ dev = [
     "flake8>=6.1",
     "isort>=5.12.0",
     "black>=23.7.0",
+    "respx>=0.21",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared pytest fixtures.
+
+Most tests must run with no Tipalti env vars present (so they don't pick
+up real credentials from the developer's shell). The ``clean_env``
+autouse fixture strips every ``TIPALTI_*`` var before each test; tests
+that need credentials set them explicitly via ``monkeypatch.setenv``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_tipalti_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "TIPALTI_CLIENT_ID",
+        "TIPALTI_CLIENT_SECRET",
+        "TIPALTI_ENV",
+        "TIPALTI_API_BASE",
+        "TIPALTI_TOKEN_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def isolated_cache(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Point the token cache at a tmp dir."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return tmp_path

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,168 @@
+"""Tests for tipalti.api.auth (token cache + acquisition)."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import httpx
+import pytest
+import respx
+
+from tipalti.api._env import TipaltiEnv
+from tipalti.api.auth import (
+    REFRESH_WINDOW_SECONDS,
+    CachedToken,
+    _client_id_hash,
+    cache_path,
+    fetch_token,
+    get_token,
+    read_cached,
+    write_cache,
+)
+
+
+def _env() -> TipaltiEnv:
+    return TipaltiEnv(
+        client_id="id-1",
+        client_secret="secret",
+        env="sandbox",
+        api_base="https://api.sandbox.tipalti.com",
+        token_url="https://api.sandbox.tipalti.com/oauth2/token",
+    )
+
+
+def test_cache_path_uses_xdg_cache_home(isolated_cache, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = cache_path("sandbox")
+    assert str(path).startswith(str(isolated_cache))
+    assert path.name == "token-sandbox.json"
+
+
+def test_write_then_read_round_trip(isolated_cache) -> None:
+    env = _env()
+    token = CachedToken(
+        access_token="tok",
+        expires_at=int(time.time()) + 3600,
+        env=env.env,
+        client_id_hash=_client_id_hash(env.client_id),
+    )
+    write_cache(env, token)
+    got = read_cached(env)
+    assert got is not None
+    assert got.access_token == "tok"
+
+
+def test_cache_file_mode_is_0600(isolated_cache) -> None:
+    env = _env()
+    token = CachedToken("tok", int(time.time()) + 3600, env.env, _client_id_hash(env.client_id))
+    write_cache(env, token)
+    mode = os.stat(cache_path(env.env)).st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_expired_token_returns_none(isolated_cache) -> None:
+    env = _env()
+    expired = CachedToken("tok", int(time.time()) - 1, env.env, _client_id_hash(env.client_id))
+    write_cache(env, expired)
+    assert read_cached(env) is None
+
+
+def test_near_expiry_returns_none(isolated_cache) -> None:
+    env = _env()
+    soon = CachedToken(
+        "tok",
+        int(time.time()) + REFRESH_WINDOW_SECONDS - 1,
+        env.env,
+        _client_id_hash(env.client_id),
+    )
+    write_cache(env, soon)
+    assert read_cached(env) is None
+
+
+def test_client_id_rotation_invalidates_cache(isolated_cache) -> None:
+    env = _env()
+    token = CachedToken("tok", int(time.time()) + 3600, env.env, _client_id_hash("OLD"))
+    write_cache(env, token)
+    assert read_cached(env) is None
+
+
+def test_env_mismatch_invalidates_cache(isolated_cache) -> None:
+    env = _env()
+    token = CachedToken(
+        "tok", int(time.time()) + 3600, "production", _client_id_hash(env.client_id)
+    )
+    # Manually put production-tagged token at the sandbox path:
+    path = cache_path(env.env)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "access_token": token.access_token,
+                "expires_at": token.expires_at,
+                "env": token.env,
+                "client_id_hash": token.client_id_hash,
+            }
+        )
+    )
+    assert read_cached(env) is None
+
+
+def test_corrupt_cache_returns_none(isolated_cache) -> None:
+    env = _env()
+    path = cache_path(env.env)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not json")
+    assert read_cached(env) is None
+
+
+def test_missing_cache_returns_none(isolated_cache) -> None:
+    assert read_cached(_env()) is None
+
+
+def test_fetch_token_success(isolated_cache, respx_mock: respx.MockRouter) -> None:
+    env = _env()
+    respx_mock.post(env.token_url).mock(
+        return_value=httpx.Response(200, json={"access_token": "abc", "expires_in": 3600})
+    )
+    token = fetch_token(env)
+    assert token.access_token == "abc"
+    assert token.env == env.env
+    assert token.expires_at > int(time.time()) + 3000
+
+
+def test_fetch_token_http_error_raises(isolated_cache, respx_mock: respx.MockRouter) -> None:
+    env = _env()
+    respx_mock.post(env.token_url).mock(
+        return_value=httpx.Response(401, json={"error": "invalid_client"})
+    )
+    from tipalti.cli._errors import AfiError
+
+    with pytest.raises(AfiError) as exc:
+        fetch_token(env)
+    assert "auth failed" in exc.value.message
+
+
+def test_get_token_uses_cache(isolated_cache, respx_mock: respx.MockRouter) -> None:
+    env = _env()
+    write_cache(
+        env,
+        CachedToken("cached", int(time.time()) + 3600, env.env, _client_id_hash(env.client_id)),
+    )
+    route = respx_mock.post(env.token_url)
+    token = get_token(env)
+    assert token.access_token == "cached"
+    assert route.call_count == 0
+
+
+def test_get_token_misses_cache_then_fetches_and_writes(
+    isolated_cache, respx_mock: respx.MockRouter
+) -> None:
+    env = _env()
+    respx_mock.post(env.token_url).mock(
+        return_value=httpx.Response(200, json={"access_token": "fresh", "expires_in": 1800})
+    )
+    token = get_token(env)
+    assert token.access_token == "fresh"
+    again = read_cached(env)
+    assert again is not None and again.access_token == "fresh"

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -166,3 +166,79 @@ def test_get_token_misses_cache_then_fetches_and_writes(
     assert token.access_token == "fresh"
     again = read_cached(env)
     assert again is not None and again.access_token == "fresh"
+
+
+# ---- symlink-safe write (Qodo finding) -------------------------------------
+
+
+def test_cache_write_is_symlink_safe(isolated_cache, tmp_path) -> None:
+    """Pre-creating a symlink at the cache path must NOT redirect the write.
+
+    Before the fix, ``os.open(path, O_TRUNC)`` would follow the symlink and
+    truncate the linked file. After the fix, the write goes through a
+    same-directory tempfile and ``os.replace``, which atomically swaps the
+    symlink for the new regular file.
+    """
+    env = _env()
+    target = tmp_path / "DO_NOT_TRUNCATE.txt"
+    target.write_text("important contents")
+    cache_root = cache_path(env.env)
+    cache_root.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(target, cache_root)
+
+    write_cache(
+        env,
+        CachedToken("tok", int(time.time()) + 3600, env.env, _client_id_hash(env.client_id)),
+    )
+
+    # The linked-to file must not have been touched.
+    assert target.read_text() == "important contents"
+    # The cache path must now be a regular file (the symlink was atomically
+    # replaced) with the token JSON.
+    assert cache_root.is_file()
+    assert not cache_root.is_symlink()
+    payload = json.loads(cache_root.read_text())
+    assert payload["access_token"] == "tok"
+
+
+# ---- fetch_token robustness (Copilot finding) -------------------------------
+
+
+def test_fetch_token_non_json_body_raises_afi_error(
+    isolated_cache, respx_mock: respx.MockRouter
+) -> None:
+    env = _env()
+    respx_mock.post(env.token_url).mock(return_value=httpx.Response(200, text="<html>nope</html>"))
+    from tipalti.cli._errors import EXIT_USER_ERROR, AfiError
+
+    with pytest.raises(AfiError) as exc:
+        fetch_token(env)
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "invalid token response" in exc.value.message
+
+
+def test_fetch_token_missing_access_token_raises_afi_error(
+    isolated_cache, respx_mock: respx.MockRouter
+) -> None:
+    env = _env()
+    respx_mock.post(env.token_url).mock(return_value=httpx.Response(200, json={"expires_in": 3600}))
+    from tipalti.cli._errors import EXIT_USER_ERROR, AfiError
+
+    with pytest.raises(AfiError) as exc:
+        fetch_token(env)
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "invalid token response" in exc.value.message
+
+
+def test_fetch_token_zero_expires_raises_afi_error(
+    isolated_cache, respx_mock: respx.MockRouter
+) -> None:
+    env = _env()
+    respx_mock.post(env.token_url).mock(
+        return_value=httpx.Response(200, json={"access_token": "tok", "expires_in": 0})
+    )
+    from tipalti.cli._errors import EXIT_USER_ERROR, AfiError
+
+    with pytest.raises(AfiError) as exc:
+        fetch_token(env)
+    assert exc.value.code == EXIT_USER_ERROR

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,177 @@
+"""Tests for tipalti.api.client.TipaltiClient."""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+import respx
+
+from tipalti.api._env import TipaltiEnv
+from tipalti.api.auth import CachedToken, _client_id_hash, write_cache
+from tipalti.api.client import TipaltiClient, _normalize_envelope
+from tipalti.cli._errors import EXIT_USER_ERROR, AfiError
+
+
+def _env() -> TipaltiEnv:
+    return TipaltiEnv(
+        client_id="id-1",
+        client_secret="secret",
+        env="sandbox",
+        api_base="https://api.sandbox.tipalti.com",
+        token_url="https://api.sandbox.tipalti.com/oauth2/token",
+    )
+
+
+@pytest.fixture
+def primed(isolated_cache):
+    """Prime the on-disk cache so tests don't have to mock token endpoints."""
+    env = _env()
+    write_cache(
+        env,
+        CachedToken(
+            "fake-token",
+            int(time.time()) + 3600,
+            env.env,
+            _client_id_hash(env.client_id),
+        ),
+    )
+    return env
+
+
+# ---- envelope normalization ------------------------------------------------
+
+
+def test_normalize_envelope_items_field() -> None:
+    env = _normalize_envelope({"items": [{"id": 1}], "nextPageToken": "tok"}, limit=1)
+    assert env == {"items": [{"id": 1}], "next_cursor": "tok"}
+
+
+def test_normalize_envelope_value_field_odata() -> None:
+    env = _normalize_envelope(
+        {"value": [{"id": "a"}, {"id": "b"}], "@odata.nextLink": "skip=2"},
+        limit=2,
+    )
+    assert env["items"] == [{"id": "a"}, {"id": "b"}]
+    assert env["next_cursor"] == "skip=2"
+
+
+def test_normalize_envelope_short_page_drops_cursor() -> None:
+    env = _normalize_envelope({"items": [{"id": 1}], "nextPageToken": "tok"}, limit=10)
+    assert env["next_cursor"] is None
+
+
+def test_normalize_envelope_bare_array() -> None:
+    env = _normalize_envelope([{"id": 1}], limit=10)
+    assert env == {"items": [{"id": 1}], "next_cursor": None}
+
+
+# ---- list / get -------------------------------------------------------------
+
+
+def test_payee_list_happy_path(primed, respx_mock: respx.MockRouter) -> None:
+    route = respx_mock.get("https://api.sandbox.tipalti.com/v2/payees").mock(
+        return_value=httpx.Response(
+            200, json={"items": [{"id": "p1"}], "nextPageToken": "next-tok"}
+        )
+    )
+    with TipaltiClient(primed) as client:
+        envelope = client.payees.list(limit=1)
+    assert envelope == {"items": [{"id": "p1"}], "next_cursor": "next-tok"}
+    assert route.call_count == 1
+    call = route.calls.last
+    assert call.request.headers["authorization"] == "Bearer fake-token"
+    url = str(call.request.url)
+    assert "top=1" in url and ("$top=1" in url or "%24top=1" in url)
+
+
+def test_invoice_list_with_filter_and_cursor(primed, respx_mock: respx.MockRouter) -> None:
+    route = respx_mock.get("https://api.sandbox.tipalti.com/v2/invoices").mock(
+        return_value=httpx.Response(200, json={"items": [], "nextPageToken": ""})
+    )
+    with TipaltiClient(primed) as client:
+        client.invoices.list(limit=10, cursor="abc", filter="status eq 'Approved'")
+    url = str(route.calls.last.request.url)
+    assert "%24filter=status+eq+%27Approved%27" in url or "$filter=status" in url
+    assert "$skiptoken=abc" in url or "%24skiptoken=abc" in url
+
+
+def test_bill_get_happy_path(primed, respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/bills/B-1").mock(
+        return_value=httpx.Response(200, json={"id": "B-1", "status": "Open"})
+    )
+    with TipaltiClient(primed) as client:
+        record = client.bills.get("B-1")
+    assert record == {"id": "B-1", "status": "Open"}
+
+
+def test_get_404_includes_resource(primed, respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/payees/missing").mock(
+        return_value=httpx.Response(404, json={})
+    )
+    with TipaltiClient(primed) as client:
+        with pytest.raises(AfiError) as exc:
+            client.payees.get("missing")
+    assert exc.value.code == EXIT_USER_ERROR
+    assert exc.value.message == "not found: payee missing"
+
+
+def test_list_429_retries_once(primed, respx_mock: respx.MockRouter) -> None:
+    route = respx_mock.get("https://api.sandbox.tipalti.com/v2/payees").mock(
+        side_effect=[
+            httpx.Response(429, headers={"Retry-After": "0"}, json={}),
+            httpx.Response(200, json={"items": []}),
+        ]
+    )
+    with TipaltiClient(primed) as client:
+        envelope = client.payees.list(limit=1)
+    assert envelope["items"] == []
+    assert route.call_count == 2
+
+
+def test_list_429_after_retry_raises(primed, respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/payees").mock(
+        return_value=httpx.Response(429, headers={"Retry-After": "0"}, json={})
+    )
+    with TipaltiClient(primed) as client:
+        with pytest.raises(AfiError) as exc:
+            client.payees.list(limit=1)
+    assert exc.value.message == "rate limited"
+
+
+def test_list_5xx_retries_then_succeeds(primed, respx_mock: respx.MockRouter) -> None:
+    route = respx_mock.get("https://api.sandbox.tipalti.com/v2/payees").mock(
+        side_effect=[
+            httpx.Response(503, json={}),
+            httpx.Response(200, json={"items": [{"id": "p1"}]}),
+        ]
+    )
+    with TipaltiClient(primed) as client:
+        envelope = client.payees.list(limit=1)
+    assert envelope["items"] == [{"id": "p1"}]
+    assert route.call_count == 2
+
+
+# ---- whoami ----------------------------------------------------------------
+
+
+def test_whoami_authenticated(primed, respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/me").mock(
+        return_value=httpx.Response(200, json={"id": "me-1", "name": "Alice"})
+    )
+    with TipaltiClient(primed) as client:
+        result = client.whoami()
+    assert result["status"] == "authenticated"
+    assert result["principal"]["id"] == "me-1"
+    assert result["env"] == "sandbox"
+
+
+def test_whoami_401_returns_unauthenticated(primed, respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/me").mock(
+        return_value=httpx.Response(401, json={})
+    )
+    with TipaltiClient(primed) as client:
+        result = client.whoami()
+    assert result["status"] == "unauthenticated"
+    assert result["principal"] is None

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -48,13 +48,35 @@ def test_normalize_envelope_items_field() -> None:
     assert env == {"items": [{"id": 1}], "next_cursor": "tok"}
 
 
-def test_normalize_envelope_value_field_odata() -> None:
+def test_normalize_envelope_value_field_odata_extracts_skiptoken() -> None:
     env = _normalize_envelope(
-        {"value": [{"id": "a"}, {"id": "b"}], "@odata.nextLink": "skip=2"},
+        {
+            "value": [{"id": "a"}, {"id": "b"}],
+            "@odata.nextLink": "https://api.sandbox.tipalti.com/v2/payees?$skiptoken=tok-2&$top=2",
+        },
         limit=2,
     )
     assert env["items"] == [{"id": "a"}, {"id": "b"}]
-    assert env["next_cursor"] == "skip=2"
+    assert env["next_cursor"] == "tok-2"
+
+
+def test_normalize_envelope_odata_link_falls_back_to_skip() -> None:
+    env = _normalize_envelope(
+        {
+            "value": [{"id": "a"}],
+            "@odata.nextLink": "https://api.sandbox.tipalti.com/v2/payees?$skip=10",
+        },
+        limit=1,
+    )
+    assert env["next_cursor"] == "10"
+
+
+def test_normalize_envelope_odata_link_without_cursor_param_yields_none() -> None:
+    env = _normalize_envelope(
+        {"value": [{"id": "a"}], "@odata.nextLink": "https://api.example.com/no-params"},
+        limit=1,
+    )
+    assert env["next_cursor"] is None
 
 
 def test_normalize_envelope_short_page_drops_cursor() -> None:
@@ -151,6 +173,31 @@ def test_list_5xx_retries_then_succeeds(primed, respx_mock: respx.MockRouter) ->
         envelope = client.payees.list(limit=1)
     assert envelope["items"] == [{"id": "p1"}]
     assert route.call_count == 2
+
+
+def test_429_retry_after_does_not_oversleep(
+    primed, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``Retry-After: 7`` should sleep exactly 7s — not 8s (bug fixed)."""
+    sleeps: list[float] = []
+
+    def _record_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("tipalti.api.client.time.sleep", _record_sleep)
+
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/payees").mock(
+        side_effect=[
+            httpx.Response(429, headers={"Retry-After": "7"}, json={}),
+            httpx.Response(200, json={"items": []}),
+        ]
+    )
+    with TipaltiClient(primed) as client:
+        client.payees.list(limit=1)
+    # The fix collapses dual-sleep into a single per-iteration delay:
+    # exactly one positive sleep of 7.0 seconds before the retry attempt.
+    positive_sleeps = [s for s in sleeps if s > 0]
+    assert positive_sleeps == [7.0]
 
 
 # ---- whoami ----------------------------------------------------------------

--- a/tests/test_api_env.py
+++ b/tests/test_api_env.py
@@ -1,0 +1,84 @@
+"""Tests for tipalti.api._env.load_env."""
+
+from __future__ import annotations
+
+import pytest
+
+from tipalti.api._env import (
+    DEFAULT_ENV,
+    VALID_ENVS,
+    TipaltiEnv,
+    load_env,
+)
+from tipalti.cli._errors import EXIT_ENV_ERROR, AfiError
+
+
+def test_load_env_defaults_to_sandbox() -> None:
+    env = load_env({"TIPALTI_CLIENT_ID": "id", "TIPALTI_CLIENT_SECRET": "s"})
+    assert isinstance(env, TipaltiEnv)
+    assert env.env == DEFAULT_ENV == "sandbox"
+    assert env.api_base == "https://api.sandbox.tipalti.com"
+    assert env.token_url == "https://api.sandbox.tipalti.com/oauth2/token"
+    assert env.client_id == "id"
+    assert env.client_secret == "s"
+
+
+def test_load_env_production() -> None:
+    env = load_env(
+        {"TIPALTI_CLIENT_ID": "id", "TIPALTI_CLIENT_SECRET": "s", "TIPALTI_ENV": "production"}
+    )
+    assert env.env == "production"
+    assert env.api_base == "https://api.tipalti.com"
+    assert env.token_url == "https://api.tipalti.com/oauth2/token"
+
+
+def test_load_env_overrides_url() -> None:
+    env = load_env(
+        {
+            "TIPALTI_CLIENT_ID": "id",
+            "TIPALTI_CLIENT_SECRET": "s",
+            "TIPALTI_API_BASE": "https://custom.example.com/",
+            "TIPALTI_TOKEN_URL": "https://custom.example.com/oauth/token",
+        }
+    )
+    assert env.api_base == "https://custom.example.com"  # trailing slash stripped
+    assert env.token_url == "https://custom.example.com/oauth/token"
+
+
+def test_load_env_missing_creds_raises() -> None:
+    with pytest.raises(AfiError) as exc:
+        load_env({})
+    assert exc.value.code == EXIT_ENV_ERROR
+    assert "TIPALTI_CLIENT_ID" in exc.value.message
+
+
+def test_load_env_blank_creds_raises() -> None:
+    with pytest.raises(AfiError) as exc:
+        load_env({"TIPALTI_CLIENT_ID": "  ", "TIPALTI_CLIENT_SECRET": ""})
+    assert exc.value.code == EXIT_ENV_ERROR
+
+
+def test_load_env_unknown_env_raises() -> None:
+    with pytest.raises(AfiError) as exc:
+        load_env(
+            {
+                "TIPALTI_CLIENT_ID": "id",
+                "TIPALTI_CLIENT_SECRET": "s",
+                "TIPALTI_ENV": "staging",
+            }
+        )
+    assert exc.value.code == EXIT_ENV_ERROR
+    assert "staging" in exc.value.message
+    for valid in VALID_ENVS:
+        assert valid in exc.value.remediation
+
+
+def test_load_env_case_insensitive() -> None:
+    env = load_env(
+        {
+            "TIPALTI_CLIENT_ID": "id",
+            "TIPALTI_CLIENT_SECRET": "s",
+            "TIPALTI_ENV": "PRODUCTION",
+        }
+    )
+    assert env.env == "production"

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -1,0 +1,69 @@
+"""Tests for tipalti.api.errors."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tipalti.api.errors import from_http_response, from_transport_error
+from tipalti.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR
+
+
+def _resp(status: int, body: object = b"", headers: dict[str, str] | None = None) -> httpx.Response:
+    if isinstance(body, (dict, list)):
+        return httpx.Response(status, json=body, headers=headers or {})
+    return httpx.Response(
+        status,
+        content=body if isinstance(body, bytes) else str(body).encode(),
+        headers=headers or {},
+    )
+
+
+@pytest.mark.parametrize(
+    "status,fragment",
+    [
+        (400, "bad request"),
+        (401, "auth failed"),
+        (403, "forbidden"),
+        (429, "rate limited"),
+        (500, "tipalti API 500"),
+        (502, "tipalti API 502"),
+        (503, "tipalti API 503"),
+    ],
+)
+def test_from_http_response_status_messages(status: int, fragment: str) -> None:
+    err = from_http_response(_resp(status, {"message": "x"}))
+    assert err.code == EXIT_USER_ERROR
+    assert fragment in err.message
+
+
+def test_404_with_resource_id() -> None:
+    err = from_http_response(_resp(404, {}), resource="payee", resource_id="abc")
+    assert err.message == "not found: payee abc"
+
+
+def test_404_without_resource_id() -> None:
+    err = from_http_response(_resp(404, {}))
+    assert err.message == "not found"
+
+
+def test_429_includes_retry_after() -> None:
+    err = from_http_response(_resp(429, {}, headers={"Retry-After": "7"}))
+    assert "7s" in err.remediation
+
+
+def test_short_api_message_picks_message_field() -> None:
+    err = from_http_response(_resp(400, {"message": "bad filter syntax"}))
+    assert "bad filter syntax" in err.message
+
+
+def test_short_api_message_text_fallback() -> None:
+    err = from_http_response(_resp(500, "raw plain text"))
+    assert "raw plain text" in err.message
+
+
+def test_from_transport_error_is_env_error() -> None:
+    err = from_transport_error(httpx.ConnectError("dns lookup failed"))
+    assert err.code == EXIT_ENV_ERROR
+    assert "cannot reach tipalti" in err.message
+    assert "ConnectError" in err.message

--- a/tests/test_cli_bill.py
+++ b/tests/test_cli_bill.py
@@ -1,0 +1,49 @@
+"""Tests for `tipalti bill {list,get}` (mirrors test_cli_payee shape)."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import httpx
+import pytest
+import respx
+
+from tipalti.api._env import load_env
+from tipalti.api.auth import CachedToken, _client_id_hash, write_cache
+from tipalti.cli import main
+
+
+@pytest.fixture
+def auth(monkeypatch: pytest.MonkeyPatch, isolated_cache) -> None:
+    monkeypatch.setenv("TIPALTI_CLIENT_ID", "id-1")
+    monkeypatch.setenv("TIPALTI_CLIENT_SECRET", "secret")
+    env = load_env()
+    write_cache(
+        env,
+        CachedToken("fake", int(time.time()) + 3600, env.env, _client_id_hash(env.client_id)),
+    )
+
+
+def test_bill_list_empty(
+    auth: None, capsys: pytest.CaptureFixture[str], respx_mock: respx.MockRouter
+) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/bills").mock(
+        return_value=httpx.Response(200, json={"items": []})
+    )
+    rc = main(["bill", "list"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "No results" in out
+
+
+def test_bill_get_json(
+    auth: None, capsys: pytest.CaptureFixture[str], respx_mock: respx.MockRouter
+) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/bills/B-1").mock(
+        return_value=httpx.Response(200, json={"id": "B-1", "status": "Open"})
+    )
+    rc = main(["bill", "get", "B-1", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"id": "B-1", "status": "Open"}

--- a/tests/test_cli_invoice.py
+++ b/tests/test_cli_invoice.py
@@ -1,0 +1,69 @@
+"""Tests for `tipalti invoice {list,get}` (mirrors test_cli_payee shape)."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import httpx
+import pytest
+import respx
+
+from tipalti.api._env import load_env
+from tipalti.api.auth import CachedToken, _client_id_hash, write_cache
+from tipalti.cli import main
+
+
+@pytest.fixture
+def auth(monkeypatch: pytest.MonkeyPatch, isolated_cache) -> None:
+    monkeypatch.setenv("TIPALTI_CLIENT_ID", "id-1")
+    monkeypatch.setenv("TIPALTI_CLIENT_SECRET", "secret")
+    env = load_env()
+    write_cache(
+        env,
+        CachedToken("fake", int(time.time()) + 3600, env.env, _client_id_hash(env.client_id)),
+    )
+
+
+def test_invoice_list_json(
+    auth: None, capsys: pytest.CaptureFixture[str], respx_mock: respx.MockRouter
+) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/invoices").mock(
+        return_value=httpx.Response(200, json={"items": [{"id": "inv-1", "status": "Approved"}]})
+    )
+    rc = main(["invoice", "list", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["items"][0]["id"] == "inv-1"
+
+
+def test_invoice_get_markdown(
+    auth: None, capsys: pytest.CaptureFixture[str], respx_mock: respx.MockRouter
+) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/invoices/inv-1").mock(
+        return_value=httpx.Response(200, json={"id": "inv-1", "amount": 100, "status": "Approved"})
+    )
+    rc = main(["invoice", "get", "inv-1"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.startswith("# invoice inv-1")
+    assert "**amount:** `100`" in out
+
+
+def test_invoice_list_next_cursor_footer(
+    auth: None, capsys: pytest.CaptureFixture[str], respx_mock: respx.MockRouter
+) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/invoices").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [{"id": f"i{n}"} for n in range(2)],
+                "nextPageToken": "tok-next",
+            },
+        )
+    )
+    rc = main(["invoice", "list", "--limit", "2"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Next page:" in out
+    assert "tipalti invoice list --cursor=tok-next" in out

--- a/tests/test_cli_learn.py
+++ b/tests/test_cli_learn.py
@@ -22,11 +22,35 @@ def test_learn_json_parseable(capsys: pytest.CaptureFixture[str]) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["tool"] == "tipalti"
     assert any(c["path"] == ["whoami"] for c in payload["commands"])
+    for path in (["payee", "list"], ["invoice", "list"], ["bill", "list"]):
+        assert any(c["path"] == path for c in payload["commands"])
+    assert "TIPALTI_CLIENT_ID" in payload["env_vars"]
 
 
 def test_explain_self(capsys: pytest.CaptureFixture[str]) -> None:
     assert main(["explain", "tipalti"]) == 0
     assert capsys.readouterr().out.startswith("#")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ["auth"],
+        ["payee"],
+        ["payee", "list"],
+        ["payee", "get"],
+        ["invoice"],
+        ["invoice", "list"],
+        ["invoice", "get"],
+        ["bill"],
+        ["bill", "list"],
+        ["bill", "get"],
+    ],
+)
+def test_explain_new_entries(capsys: pytest.CaptureFixture[str], path: list[str]) -> None:
+    assert main(["explain", *path]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("#")
 
 
 def test_explain_unknown_path_fails_with_hint(

--- a/tests/test_cli_payee.py
+++ b/tests/test_cli_payee.py
@@ -1,0 +1,116 @@
+"""Tests for `tipalti payee {list,get}`."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import httpx
+import pytest
+import respx
+
+from tipalti.api._env import load_env
+from tipalti.api.auth import CachedToken, _client_id_hash, write_cache
+from tipalti.cli import main
+
+
+@pytest.fixture
+def auth(monkeypatch: pytest.MonkeyPatch, isolated_cache) -> None:
+    monkeypatch.setenv("TIPALTI_CLIENT_ID", "id-1")
+    monkeypatch.setenv("TIPALTI_CLIENT_SECRET", "secret")
+    env = load_env()
+    write_cache(
+        env,
+        CachedToken("fake", int(time.time()) + 3600, env.env, _client_id_hash(env.client_id)),
+    )
+
+
+def test_payee_list_markdown(
+    auth: None, capsys: pytest.CaptureFixture[str], respx_mock: respx.MockRouter
+) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/payees").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [
+                    {"id": "p1", "refCode": "REF-1", "name": "Alice", "status": "Active"},
+                    {"id": "p2", "refCode": "REF-2", "name": "Bob", "status": "Inactive"},
+                ],
+                "nextPageToken": "",
+            },
+        )
+    )
+    rc = main(["payee", "list", "--limit", "2"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.startswith("## payee list")
+    assert "| id | refCode | name | status |" in out
+    assert "REF-1" in out
+    assert "End of results" in out
+
+
+def test_payee_list_json(
+    auth: None, capsys: pytest.CaptureFixture[str], respx_mock: respx.MockRouter
+) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/payees").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [{"id": "p1"}],
+                "nextPageToken": "next-tok",
+            },
+        )
+    )
+    rc = main(["payee", "list", "--limit", "1", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["items"] == [{"id": "p1"}]
+    assert payload["next_cursor"] == "next-tok"
+
+
+def test_payee_list_filter_forwarded(
+    auth: None, capsys: pytest.CaptureFixture[str], respx_mock: respx.MockRouter
+) -> None:
+    route = respx_mock.get("https://api.sandbox.tipalti.com/v2/payees").mock(
+        return_value=httpx.Response(200, json={"items": []})
+    )
+    main(["payee", "list", "--filter", "status eq 'Active'", "--json"])
+    url = str(route.calls.last.request.url)
+    assert "Active" in url
+    assert "status" in url
+
+
+def test_payee_get_404_message(
+    auth: None, capsys: pytest.CaptureFixture[str], respx_mock: respx.MockRouter
+) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/payees/missing").mock(
+        return_value=httpx.Response(404, json={})
+    )
+    rc = main(["payee", "get", "missing"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not found: payee missing" in err
+
+
+def test_payee_get_markdown(
+    auth: None, capsys: pytest.CaptureFixture[str], respx_mock: respx.MockRouter
+) -> None:
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/payees/p1").mock(
+        return_value=httpx.Response(
+            200, json={"id": "p1", "name": "Alice", "address": {"city": "NYC"}}
+        )
+    )
+    rc = main(["payee", "get", "p1"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.startswith("# payee p1")
+    assert "**id:** p1" in out
+    assert "**name:** Alice" in out
+    assert "## address" in out
+
+
+def test_payee_list_missing_creds(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["payee", "list"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "TIPALTI_CLIENT_ID" in err

--- a/tests/test_cli_whoami.py
+++ b/tests/test_cli_whoami.py
@@ -1,21 +1,78 @@
-"""Tests for `tipalti whoami` (auth probe stub)."""
+"""Tests for `tipalti whoami` (real auth probe)."""
 
 from __future__ import annotations
 
 import json
+import time
 
+import httpx
 import pytest
+import respx
 
+from tipalti.api._env import load_env
+from tipalti.api.auth import CachedToken, _client_id_hash, write_cache
 from tipalti.cli import main
 
 
-def test_whoami_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
-    assert main(["whoami"]) == 0
-    assert "unauthenticated" in capsys.readouterr().out
+def _prime_token() -> None:
+    env = load_env()
+    write_cache(
+        env,
+        CachedToken("fake", int(time.time()) + 3600, env.env, _client_id_hash(env.client_id)),
+    )
 
 
-def test_whoami_json(capsys: pytest.CaptureFixture[str]) -> None:
-    assert main(["whoami", "--json"]) == 0
+def test_whoami_unauthenticated_no_env(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["whoami"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "unauthenticated" in out
+    assert out.startswith("# tipalti whoami")
+
+
+def test_whoami_unauthenticated_no_env_json(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["whoami", "--json"])
+    assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "unauthenticated"
     assert payload["principal"] is None
+    assert payload["env"] is None
+
+
+def test_whoami_401_is_unauthenticated_exit_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cache,
+    capsys: pytest.CaptureFixture[str],
+    respx_mock: respx.MockRouter,
+) -> None:
+    monkeypatch.setenv("TIPALTI_CLIENT_ID", "id")
+    monkeypatch.setenv("TIPALTI_CLIENT_SECRET", "s")
+    _prime_token()
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/me").mock(
+        return_value=httpx.Response(401, json={})
+    )
+    rc = main(["whoami", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "unauthenticated"
+    assert payload["env"] == "sandbox"
+
+
+def test_whoami_authenticated_markdown(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cache,
+    capsys: pytest.CaptureFixture[str],
+    respx_mock: respx.MockRouter,
+) -> None:
+    monkeypatch.setenv("TIPALTI_CLIENT_ID", "id")
+    monkeypatch.setenv("TIPALTI_CLIENT_SECRET", "s")
+    _prime_token()
+    respx_mock.get("https://api.sandbox.tipalti.com/v2/me").mock(
+        return_value=httpx.Response(200, json={"id": "me-1", "name": "Alice"})
+    )
+    rc = main(["whoami"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "authenticated" in out
+    assert "me-1" in out
+    assert "Alice" in out

--- a/tests/test_cli_whoami.py
+++ b/tests/test_cli_whoami.py
@@ -76,3 +76,19 @@ def test_whoami_authenticated_markdown(
     assert "authenticated" in out
     assert "me-1" in out
     assert "Alice" in out
+
+
+def test_whoami_unknown_env_propagates_error(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cache,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unknown TIPALTI_ENV must NOT be swallowed as 'unauthenticated'."""
+    monkeypatch.setenv("TIPALTI_CLIENT_ID", "id")
+    monkeypatch.setenv("TIPALTI_CLIENT_SECRET", "s")
+    monkeypatch.setenv("TIPALTI_ENV", "staging")  # not in VALID_ENVS
+    rc = main(["whoami"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unknown TIPALTI_ENV" in err
+    assert "staging" in err

--- a/tipalti/api/__init__.py
+++ b/tipalti/api/__init__.py
@@ -1,0 +1,15 @@
+"""CLI-agnostic HTTP layer for the Tipalti REST v2 API.
+
+This subpackage knows nothing about argparse or the CLI's emit helpers.
+Any caller (the CLI in this repo, a different harness, a notebook) can use
+:class:`TipaltiClient` directly; failures surface as
+:class:`tipalti.cli._errors.AfiError` with HTTP-aware codes / messages /
+remediations.
+"""
+
+from __future__ import annotations
+
+from tipalti.api._env import TipaltiEnv, load_env
+from tipalti.api.client import TipaltiClient
+
+__all__ = ["TipaltiClient", "TipaltiEnv", "load_env"]

--- a/tipalti/api/_env.py
+++ b/tipalti/api/_env.py
@@ -1,0 +1,83 @@
+"""Environment-variable resolution for the Tipalti REST v2 client.
+
+The CLI reads three required and two optional env vars:
+
+* ``TIPALTI_CLIENT_ID``   — OAuth2 client ID (required)
+* ``TIPALTI_CLIENT_SECRET`` — OAuth2 client secret (required)
+* ``TIPALTI_ENV``         — ``sandbox`` | ``production``; default ``sandbox``
+* ``TIPALTI_API_BASE``    — override the default API base URL for the env
+* ``TIPALTI_TOKEN_URL``   — override the default OAuth2 token URL for the env
+
+The default base URLs match Tipalti's documented hosts; the override env
+vars exist so deployers can correct them at runtime without code changes
+(the spec fixes the *shape*, not the URL strings).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from tipalti.cli._errors import EXIT_ENV_ERROR, AfiError
+
+VALID_ENVS = ("sandbox", "production")
+DEFAULT_ENV = "sandbox"
+
+_DEFAULT_API_BASE: dict[str, str] = {
+    "sandbox": "https://api.sandbox.tipalti.com",
+    "production": "https://api.tipalti.com",
+}
+_DEFAULT_TOKEN_URL: dict[str, str] = {
+    "sandbox": "https://api.sandbox.tipalti.com/oauth2/token",
+    "production": "https://api.tipalti.com/oauth2/token",
+}
+
+
+@dataclass(frozen=True)
+class TipaltiEnv:
+    """Resolved Tipalti environment + credentials."""
+
+    client_id: str
+    client_secret: str
+    env: str
+    api_base: str
+    token_url: str
+
+
+def load_env(source: Mapping[str, str] | None = None) -> TipaltiEnv:
+    """Read env vars and return a :class:`TipaltiEnv`.
+
+    ``source`` defaults to ``os.environ``; tests pass an explicit mapping.
+    Raises :class:`AfiError` with ``EXIT_ENV_ERROR`` for missing creds or
+    unknown ``TIPALTI_ENV`` values.
+    """
+    env_map = source if source is not None else os.environ
+
+    env_name = (env_map.get("TIPALTI_ENV") or DEFAULT_ENV).strip().lower()
+    if env_name not in VALID_ENVS:
+        raise AfiError(
+            code=EXIT_ENV_ERROR,
+            message=f"unknown TIPALTI_ENV: {env_name!r}",
+            remediation=f"use one of: {', '.join(VALID_ENVS)}",
+        )
+
+    client_id = (env_map.get("TIPALTI_CLIENT_ID") or "").strip()
+    client_secret = (env_map.get("TIPALTI_CLIENT_SECRET") or "").strip()
+    if not client_id or not client_secret:
+        raise AfiError(
+            code=EXIT_ENV_ERROR,
+            message="missing TIPALTI_CLIENT_ID/SECRET",
+            remediation="set env vars; see 'tipalti explain auth'",
+        )
+
+    api_base = (env_map.get("TIPALTI_API_BASE") or _DEFAULT_API_BASE[env_name]).rstrip("/")
+    token_url = env_map.get("TIPALTI_TOKEN_URL") or _DEFAULT_TOKEN_URL[env_name]
+
+    return TipaltiEnv(
+        client_id=client_id,
+        client_secret=client_secret,
+        env=env_name,
+        api_base=api_base,
+        token_url=token_url,
+    )

--- a/tipalti/api/_env.py
+++ b/tipalti/api/_env.py
@@ -69,6 +69,7 @@ def load_env(source: Mapping[str, str] | None = None) -> TipaltiEnv:
             code=EXIT_ENV_ERROR,
             message="missing TIPALTI_CLIENT_ID/SECRET",
             remediation="set env vars; see 'tipalti explain auth'",
+            kind="missing_creds",
         )
 
     api_base = (env_map.get("TIPALTI_API_BASE") or _DEFAULT_API_BASE[env_name]).rstrip("/")

--- a/tipalti/api/auth.py
+++ b/tipalti/api/auth.py
@@ -1,0 +1,150 @@
+"""OAuth2 client-credentials acquisition with on-disk token cache.
+
+Cache file: ``$XDG_CACHE_HOME/tipalti/token-<env>.json`` (fallback
+``~/.cache/tipalti/...``), file mode ``0600``. The cache record includes a
+short hash of the client ID; rotating credentials invalidates the cache.
+
+Refresh window: tokens are refreshed when their remaining lifetime is less
+than :data:`REFRESH_WINDOW_SECONDS`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+from tipalti.api._env import TipaltiEnv
+from tipalti.api.errors import from_http_response, from_transport_error
+
+REFRESH_WINDOW_SECONDS = 30
+_TOKEN_REQUEST_TIMEOUT = 15.0
+
+
+@dataclass(frozen=True)
+class CachedToken:
+    access_token: str
+    expires_at: int
+    env: str
+    client_id_hash: str
+
+    def is_fresh(self, now: float | None = None) -> bool:
+        ts = time.time() if now is None else now
+        return self.expires_at - ts > REFRESH_WINDOW_SECONDS
+
+
+def _client_id_hash(client_id: str) -> str:
+    return hashlib.sha256(client_id.encode("utf-8")).hexdigest()[:16]
+
+
+def _cache_root() -> Path:
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return base / "tipalti"
+
+
+def cache_path(env: str) -> Path:
+    return _cache_root() / f"token-{env}.json"
+
+
+def read_cached(env: TipaltiEnv) -> CachedToken | None:
+    """Return a fresh cached token, or ``None`` if missing/stale/mismatched."""
+    path = cache_path(env.env)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    try:
+        token = CachedToken(
+            access_token=str(data["access_token"]),
+            expires_at=int(data["expires_at"]),
+            env=str(data["env"]),
+            client_id_hash=str(data["client_id_hash"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+    if token.env != env.env:
+        return None
+    if token.client_id_hash != _client_id_hash(env.client_id):
+        return None
+    if not token.is_fresh():
+        return None
+    return token
+
+
+def write_cache(env: TipaltiEnv, token: CachedToken) -> None:
+    path = cache_path(env.env)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "access_token": token.access_token,
+        "expires_at": token.expires_at,
+        "env": token.env,
+        "client_id_hash": token.client_id_hash,
+    }
+    # Write+chmod under a deterministic mode regardless of umask.
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+    finally:
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+
+
+def fetch_token(env: TipaltiEnv, *, transport: httpx.BaseTransport | None = None) -> CachedToken:
+    """Hit the OAuth2 token endpoint and return a fresh :class:`CachedToken`."""
+    data = {
+        "grant_type": "client_credentials",
+        "client_id": env.client_id,
+        "client_secret": env.client_secret,
+    }
+    try:
+        with httpx.Client(transport=transport, timeout=_TOKEN_REQUEST_TIMEOUT) as client:
+            response = client.post(
+                env.token_url,
+                data=data,
+                headers={"Accept": "application/json"},
+            )
+    except httpx.HTTPError as exc:
+        raise from_transport_error(exc) from exc
+
+    if response.status_code >= 400:
+        raise from_http_response(response)
+
+    body = response.json()
+    access_token = str(body.get("access_token") or "")
+    expires_in = int(body.get("expires_in") or 0)
+    if not access_token or expires_in <= 0:
+        raise from_http_response(response)
+
+    return CachedToken(
+        access_token=access_token,
+        expires_at=int(time.time()) + expires_in,
+        env=env.env,
+        client_id_hash=_client_id_hash(env.client_id),
+    )
+
+
+def get_token(env: TipaltiEnv, *, transport: httpx.BaseTransport | None = None) -> CachedToken:
+    """Return a fresh token, using the on-disk cache when valid."""
+    cached = read_cached(env)
+    if cached is not None:
+        return cached
+    token = fetch_token(env, transport=transport)
+    try:
+        write_cache(env, token)
+    except OSError:
+        # Cache is a perf optimization; a write failure shouldn't kill the call.
+        pass
+    return token

--- a/tipalti/api/auth.py
+++ b/tipalti/api/auth.py
@@ -1,8 +1,8 @@
 """OAuth2 client-credentials acquisition with on-disk token cache.
 
 Cache file: ``$XDG_CACHE_HOME/tipalti/token-<env>.json`` (fallback
-``~/.cache/tipalti/...``), file mode ``0600``. The cache record includes a
-short hash of the client ID; rotating credentials invalidates the cache.
+``$HOME/.cache/tipalti/...``), file mode ``0600``. The cache record includes
+a short hash of the client ID; rotating credentials invalidates the cache.
 
 Refresh window: tokens are refreshed when their remaining lifetime is less
 than :data:`REFRESH_WINDOW_SECONDS`.
@@ -13,6 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -21,6 +22,7 @@ import httpx
 
 from tipalti.api._env import TipaltiEnv
 from tipalti.api.errors import from_http_response, from_transport_error
+from tipalti.cli._errors import EXIT_USER_ERROR, AfiError
 
 REFRESH_WINDOW_SECONDS = 30
 _TOKEN_REQUEST_TIMEOUT = 15.0
@@ -82,6 +84,12 @@ def read_cached(env: TipaltiEnv) -> CachedToken | None:
 
 
 def write_cache(env: TipaltiEnv, token: CachedToken) -> None:
+    """Atomically write the token cache via a same-directory tempfile.
+
+    A symlink at the final path can't redirect the truncating write because
+    we open and write through ``mkstemp`` (which creates a fresh inode in
+    the same directory), then ``os.replace`` into place.
+    """
     path = cache_path(env.env)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -90,16 +98,19 @@ def write_cache(env: TipaltiEnv, token: CachedToken) -> None:
         "env": token.env,
         "client_id_hash": token.client_id_hash,
     }
-    # Write+chmod under a deterministic mode regardless of umask.
-    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    tmp_path = Path(tmp_name)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(payload, f)
-    finally:
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+    except Exception:
         try:
-            os.chmod(path, 0o600)
+            tmp_path.unlink()
         except OSError:
             pass
+        raise
 
 
 def fetch_token(env: TipaltiEnv, *, transport: httpx.BaseTransport | None = None) -> CachedToken:
@@ -122,11 +133,36 @@ def fetch_token(env: TipaltiEnv, *, transport: httpx.BaseTransport | None = None
     if response.status_code >= 400:
         raise from_http_response(response)
 
-    body = response.json()
-    access_token = str(body.get("access_token") or "")
-    expires_in = int(body.get("expires_in") or 0)
+    try:
+        body = response.json()
+    except (ValueError, json.JSONDecodeError):
+        body = None
+
+    access_token: str = ""
+    expires_in: int = 0
+    if isinstance(body, dict):
+        token_value = body.get("access_token")
+        if isinstance(token_value, str):
+            access_token = token_value
+        raw_expires = body.get("expires_in")
+        if isinstance(raw_expires, (int, float)):
+            expires_in = int(raw_expires)
+        elif isinstance(raw_expires, str):
+            try:
+                expires_in = int(float(raw_expires))
+            except ValueError:
+                expires_in = 0
+
     if not access_token or expires_in <= 0:
-        raise from_http_response(response)
+        snippet = response.text[:200].replace("\n", " ").strip()
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"invalid token response from {env.token_url} "
+                f"(status {response.status_code}): {snippet}"
+            ),
+            remediation="check TIPALTI_CLIENT_ID/SECRET and TIPALTI_TOKEN_URL",
+        )
 
     return CachedToken(
         access_token=access_token,

--- a/tipalti/api/auth.py
+++ b/tipalti/api/auth.py
@@ -59,7 +59,7 @@ def read_cached(env: TipaltiEnv) -> CachedToken | None:
     path = cache_path(env.env)
     try:
         raw = path.read_text(encoding="utf-8")
-    except (FileNotFoundError, PermissionError, OSError):
+    except OSError:
         return None
     try:
         data = json.loads(raw)
@@ -135,7 +135,7 @@ def fetch_token(env: TipaltiEnv, *, transport: httpx.BaseTransport | None = None
 
     try:
         body = response.json()
-    except (ValueError, json.JSONDecodeError):
+    except ValueError:
         body = None
 
     access_token: str = ""

--- a/tipalti/api/client.py
+++ b/tipalti/api/client.py
@@ -1,0 +1,233 @@
+"""High-level Tipalti REST v2 client used by the CLI commands.
+
+Boundaries:
+
+* No argparse, no ``emit_*``: the CLI is a thin caller around this module.
+* Every failure surfaces as :class:`tipalti.cli._errors.AfiError` (HTTP errors
+  via :mod:`tipalti.api.errors`, transport errors as ``EXIT_ENV_ERROR``).
+* Single-retry policy on 429 (honoring ``Retry-After``, capped at 10s) and
+  5xx (1s linear backoff). No more — agents own higher-level retry policy.
+
+Pagination model: ``list_*`` methods return ``{"items", "next_cursor"}``
+envelopes. ``next_cursor`` is the literal ``$skiptoken`` value to feed back
+in via ``--cursor``.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Iterable
+
+import httpx
+
+from tipalti.api._env import TipaltiEnv, load_env
+from tipalti.api.auth import get_token
+from tipalti.api.errors import from_http_response, from_transport_error
+
+DEFAULT_TIMEOUT = 30.0
+MAX_RETRY_AFTER_SECONDS = 10.0
+DEFAULT_LIMIT = 100
+MAX_LIMIT = 500
+RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+def _coerce_retry_after(value: str | None) -> float:
+    if not value:
+        return 0.0
+    try:
+        return min(float(value), MAX_RETRY_AFTER_SECONDS)
+    except ValueError:
+        return 0.0
+
+
+def _normalize_envelope(body: Any, limit: int) -> dict[str, Any]:
+    """Map a Tipalti list response into ``{"items", "next_cursor"}``.
+
+    Tipalti's REST v2 list responses commonly use either an ``items`` array
+    with a ``nextPageToken`` / ``next_cursor`` field, or an OData-style
+    ``value`` array with ``@odata.nextLink``. We accept both shapes and
+    always emit our envelope.
+    """
+    items: list[Any]
+    next_cursor: str | None = None
+
+    if isinstance(body, dict):
+        if isinstance(body.get("items"), list):
+            items = list(body["items"])
+        elif isinstance(body.get("value"), list):
+            items = list(body["value"])
+        elif isinstance(body.get("data"), list):
+            items = list(body["data"])
+        else:
+            items = []
+
+        for key in ("nextPageToken", "next_cursor", "nextCursor", "@odata.nextLink"):
+            value = body.get(key)
+            if isinstance(value, str) and value:
+                next_cursor = value
+                break
+    elif isinstance(body, list):
+        items = list(body)
+    else:
+        items = []
+
+    # Defensive: don't claim there's a next page when the page wasn't full.
+    if next_cursor and len(items) < limit:
+        next_cursor = None
+    return {"items": items, "next_cursor": next_cursor}
+
+
+class _ResourceGroup:
+    def __init__(self, client: "TipaltiClient", path: str, name: str) -> None:
+        self._client = client
+        self._path = path
+        self._name = name
+
+    def list(
+        self,
+        *,
+        limit: int = DEFAULT_LIMIT,
+        cursor: str | None = None,
+        filter: str | None = None,  # noqa: A002 — matches the user-facing flag
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"$top": min(max(limit, 1), MAX_LIMIT)}
+        if cursor:
+            params["$skiptoken"] = cursor
+        if filter:
+            params["$filter"] = filter
+        response = self._client._request("GET", self._path, params=params)
+        return _normalize_envelope(response.json(), limit=params["$top"])
+
+    def get(self, resource_id: str) -> Any:
+        response = self._client._request(
+            "GET",
+            f"{self._path}/{resource_id}",
+            resource=self._name,
+            resource_id=resource_id,
+        )
+        return response.json()
+
+
+class TipaltiClient:
+    """Thin httpx wrapper that handles auth, retry, and error mapping."""
+
+    def __init__(
+        self,
+        env: TipaltiEnv,
+        *,
+        transport: httpx.BaseTransport | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        self._env = env
+        self._transport = transport
+        self._http = httpx.Client(
+            base_url=env.api_base,
+            timeout=timeout,
+            transport=transport,
+            headers={"Accept": "application/json"},
+        )
+        self.payees = _ResourceGroup(self, "/v2/payees", "payee")
+        self.invoices = _ResourceGroup(self, "/v2/invoices", "invoice")
+        self.bills = _ResourceGroup(self, "/v2/bills", "bill")
+
+    @classmethod
+    def from_env(cls, **kwargs: Any) -> "TipaltiClient":
+        return cls(load_env(), **kwargs)
+
+    @property
+    def env(self) -> TipaltiEnv:
+        return self._env
+
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self) -> "TipaltiClient":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    # ---- auth -----------------------------------------------------------------
+
+    def _auth_headers(self) -> dict[str, str]:
+        token = get_token(self._env, transport=self._transport)
+        return {"Authorization": f"Bearer {token.access_token}"}
+
+    # ---- whoami ---------------------------------------------------------------
+
+    def whoami(self) -> dict[str, Any]:
+        """Probe the active principal. Returns ``{status, principal, env}``.
+
+        Treats 401 as ``unauthenticated`` (probe semantics, not an error).
+        Other HTTP errors propagate as :class:`AfiError`. The CLI layer
+        also catches the ``EXIT_ENV_ERROR`` path (missing creds) and maps
+        it to the same ``unauthenticated`` shape.
+        """
+        response = self._raw_request("GET", "/v2/me")
+        if response.status_code == 401:
+            return {"status": "unauthenticated", "principal": None, "env": self._env.env}
+        if response.status_code >= 400:
+            raise from_http_response(response)
+        try:
+            principal = response.json()
+        except ValueError:
+            principal = None
+        return {
+            "status": "authenticated",
+            "principal": principal,
+            "env": self._env.env,
+        }
+
+    # ---- internals ------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        resource: str | None = None,
+        resource_id: str | None = None,
+    ) -> httpx.Response:
+        response = self._raw_request(method, path, params=params)
+        if response.status_code >= 400:
+            raise from_http_response(response, resource=resource, resource_id=resource_id)
+        return response
+
+    def _raw_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        attempts: Iterable[float] = (0.0, 1.0)  # initial + one retry
+        last_response: httpx.Response | None = None
+        for attempt_index, base_delay in enumerate(attempts):
+            if base_delay:
+                time.sleep(base_delay)
+            try:
+                response = self._http.request(
+                    method,
+                    path,
+                    params=params,
+                    headers=self._auth_headers(),
+                )
+            except httpx.HTTPError as exc:
+                # Retry once on transport error too — same single-retry policy.
+                if attempt_index == 0:
+                    continue
+                raise from_transport_error(exc) from exc
+
+            if response.status_code in RETRY_STATUSES and attempt_index == 0:
+                if response.status_code == 429:
+                    retry_after = _coerce_retry_after(response.headers.get("Retry-After"))
+                    if retry_after > 0:
+                        time.sleep(retry_after - base_delay if retry_after > base_delay else 0)
+                last_response = response
+                continue
+            return response
+
+        # Both attempts produced retryable failures; surface the last one.
+        assert last_response is not None  # nosec B101
+        return last_response

--- a/tipalti/api/client.py
+++ b/tipalti/api/client.py
@@ -16,7 +16,8 @@ in via ``--cursor``.
 from __future__ import annotations
 
 import time
-from typing import Any, Iterable
+from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 
@@ -40,13 +41,32 @@ def _coerce_retry_after(value: str | None) -> float:
         return 0.0
 
 
+def _extract_skiptoken_from_url(link: str) -> str | None:
+    """Extract ``$skiptoken`` (or ``$skip``) from an OData ``@odata.nextLink`` URL.
+
+    The rest of the client treats ``next_cursor`` as the literal cursor
+    token to feed back as ``$skiptoken`` on the next request, so storing a
+    full URL here would round-trip as an invalid query parameter.
+    """
+    try:
+        qs = parse_qs(urlparse(link).query)
+    except ValueError:
+        return None
+    for key in ("$skiptoken", "$skip"):
+        value = qs.get(key)
+        if value:
+            return value[0]
+    return None
+
+
 def _normalize_envelope(body: Any, limit: int) -> dict[str, Any]:
     """Map a Tipalti list response into ``{"items", "next_cursor"}``.
 
     Tipalti's REST v2 list responses commonly use either an ``items`` array
     with a ``nextPageToken`` / ``next_cursor`` field, or an OData-style
     ``value`` array with ``@odata.nextLink``. We accept both shapes and
-    always emit our envelope.
+    always emit our envelope, with ``next_cursor`` always being a literal
+    cursor token (never a URL).
     """
     items: list[Any]
     next_cursor: str | None = None
@@ -61,11 +81,15 @@ def _normalize_envelope(body: Any, limit: int) -> dict[str, Any]:
         else:
             items = []
 
-        for key in ("nextPageToken", "next_cursor", "nextCursor", "@odata.nextLink"):
+        for key in ("nextPageToken", "next_cursor", "nextCursor"):
             value = body.get(key)
             if isinstance(value, str) and value:
                 next_cursor = value
                 break
+        if next_cursor is None:
+            link = body.get("@odata.nextLink")
+            if isinstance(link, str) and link:
+                next_cursor = _extract_skiptoken_from_url(link)
     elif isinstance(body, list):
         items = list(body)
     else:
@@ -201,11 +225,18 @@ class TipaltiClient:
         *,
         params: dict[str, Any] | None = None,
     ) -> httpx.Response:
-        attempts: Iterable[float] = (0.0, 1.0)  # initial + one retry
+        """Make a request with a single-attempt retry on 429 / 5xx / transport.
+
+        The retry delay is computed *once* per iteration: ``Retry-After`` for
+        429 (capped at ``MAX_RETRY_AFTER_SECONDS``), ``1.0s`` for 5xx and
+        transport errors. We don't stack a fixed backoff on top of
+        ``Retry-After`` — sleeping ``Retry-After: 7`` should wait exactly 7s.
+        """
+        delay = 0.0
         last_response: httpx.Response | None = None
-        for attempt_index, base_delay in enumerate(attempts):
-            if base_delay:
-                time.sleep(base_delay)
+        for attempt_index in range(2):
+            if delay > 0:
+                time.sleep(delay)
             try:
                 response = self._http.request(
                     method,
@@ -214,16 +245,16 @@ class TipaltiClient:
                     headers=self._auth_headers(),
                 )
             except httpx.HTTPError as exc:
-                # Retry once on transport error too — same single-retry policy.
                 if attempt_index == 0:
+                    delay = 1.0
                     continue
                 raise from_transport_error(exc) from exc
 
             if response.status_code in RETRY_STATUSES and attempt_index == 0:
                 if response.status_code == 429:
-                    retry_after = _coerce_retry_after(response.headers.get("Retry-After"))
-                    if retry_after > 0:
-                        time.sleep(retry_after - base_delay if retry_after > base_delay else 0)
+                    delay = _coerce_retry_after(response.headers.get("Retry-After"))
+                else:
+                    delay = 1.0
                 last_response = response
                 continue
             return response

--- a/tipalti/api/client.py
+++ b/tipalti/api/client.py
@@ -59,43 +59,45 @@ def _extract_skiptoken_from_url(link: str) -> str | None:
     return None
 
 
+_ITEMS_KEYS = ("items", "value", "data")
+_DIRECT_CURSOR_KEYS = ("nextPageToken", "next_cursor", "nextCursor")
+
+
+def _pick_items(body: Any) -> list[Any]:
+    """Pull the records list out of a list-shape response body."""
+    if isinstance(body, list):
+        return list(body)
+    if isinstance(body, dict):
+        for key in _ITEMS_KEYS:
+            value = body.get(key)
+            if isinstance(value, list):
+                return list(value)
+    return []
+
+
+def _pick_cursor(body: Any) -> str | None:
+    """Pull a literal cursor token out of a list-shape response body."""
+    if not isinstance(body, dict):
+        return None
+    for key in _DIRECT_CURSOR_KEYS:
+        value = body.get(key)
+        if isinstance(value, str) and value:
+            return value
+    link = body.get("@odata.nextLink")
+    if isinstance(link, str) and link:
+        return _extract_skiptoken_from_url(link)
+    return None
+
+
 def _normalize_envelope(body: Any, limit: int) -> dict[str, Any]:
     """Map a Tipalti list response into ``{"items", "next_cursor"}``.
 
-    Tipalti's REST v2 list responses commonly use either an ``items`` array
-    with a ``nextPageToken`` / ``next_cursor`` field, or an OData-style
-    ``value`` array with ``@odata.nextLink``. We accept both shapes and
-    always emit our envelope, with ``next_cursor`` always being a literal
-    cursor token (never a URL).
+    Accepts both ``items``/``nextPageToken`` and OData ``value``/
+    ``@odata.nextLink`` shapes. ``next_cursor`` is always a literal cursor
+    token (never a URL); short pages drop the cursor defensively.
     """
-    items: list[Any]
-    next_cursor: str | None = None
-
-    if isinstance(body, dict):
-        if isinstance(body.get("items"), list):
-            items = list(body["items"])
-        elif isinstance(body.get("value"), list):
-            items = list(body["value"])
-        elif isinstance(body.get("data"), list):
-            items = list(body["data"])
-        else:
-            items = []
-
-        for key in ("nextPageToken", "next_cursor", "nextCursor"):
-            value = body.get(key)
-            if isinstance(value, str) and value:
-                next_cursor = value
-                break
-        if next_cursor is None:
-            link = body.get("@odata.nextLink")
-            if isinstance(link, str) and link:
-                next_cursor = _extract_skiptoken_from_url(link)
-    elif isinstance(body, list):
-        items = list(body)
-    else:
-        items = []
-
-    # Defensive: don't claim there's a next page when the page wasn't full.
+    items = _pick_items(body)
+    next_cursor = _pick_cursor(body)
     if next_cursor and len(items) < limit:
         next_cursor = None
     return {"items": items, "next_cursor": next_cursor}

--- a/tipalti/api/errors.py
+++ b/tipalti/api/errors.py
@@ -1,0 +1,100 @@
+"""HTTP-status → :class:`AfiError` mapping for Tipalti REST v2 calls.
+
+Pure / side-effect free: every helper takes already-decoded inputs (status
+code, response body string, optional ``Retry-After``) and returns an
+``AfiError``. The HTTP transport layer (``api.client``) is responsible for
+calling these.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from tipalti.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, AfiError
+
+
+def _short_api_message(body: Any, fallback: str) -> str:
+    """Pick the most useful single-line message out of an API error body."""
+    if isinstance(body, dict):
+        for key in ("message", "error_description", "error", "detail", "title"):
+            value = body.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    if isinstance(body, str) and body.strip():
+        line = body.strip().splitlines()[0]
+        return line[:200]
+    return fallback
+
+
+def from_http_response(
+    response: httpx.Response,
+    *,
+    resource: str | None = None,
+    resource_id: str | None = None,
+) -> AfiError:
+    """Map an ``httpx.Response`` with non-2xx status into an :class:`AfiError`.
+
+    ``resource`` / ``resource_id`` are used for 404 messages on ``get`` calls.
+    """
+    status = response.status_code
+    try:
+        body: Any = response.json()
+    except (ValueError, httpx.DecodingError):
+        body = response.text
+
+    if status == 400:
+        return AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"bad request: {_short_api_message(body, 'invalid request')}",
+            remediation="check --filter syntax / arg values",
+        )
+    if status == 401:
+        return AfiError(
+            code=EXIT_USER_ERROR,
+            message="tipalti auth failed",
+            remediation="check TIPALTI_CLIENT_ID/SECRET/ENV",
+        )
+    if status == 403:
+        return AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"forbidden: {_short_api_message(body, 'access denied')}",
+            remediation="check the principal's permissions in Tipalti",
+        )
+    if status == 404:
+        if resource and resource_id:
+            msg = f"not found: {resource} {resource_id}"
+        elif resource:
+            msg = f"not found: {resource}"
+        else:
+            msg = "not found"
+        return AfiError(code=EXIT_USER_ERROR, message=msg, remediation="")
+    if status == 429:
+        retry_after = response.headers.get("Retry-After", "").strip()
+        hint = f"wait {retry_after}s and retry" if retry_after else "wait a moment and retry"
+        return AfiError(
+            code=EXIT_USER_ERROR,
+            message="rate limited",
+            remediation=hint,
+        )
+    if 500 <= status < 600:
+        return AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"tipalti API {status}: {_short_api_message(body, 'server error')}",
+            remediation="retry later",
+        )
+    return AfiError(
+        code=EXIT_USER_ERROR,
+        message=f"tipalti API {status}: {_short_api_message(body, 'unexpected status')}",
+        remediation="",
+    )
+
+
+def from_transport_error(exc: httpx.HTTPError) -> AfiError:
+    """Map a network/transport failure into an :class:`AfiError`."""
+    return AfiError(
+        code=EXIT_ENV_ERROR,
+        message=f"cannot reach tipalti: {exc.__class__.__name__}: {exc}",
+        remediation="check connectivity / TIPALTI_ENV",
+    )

--- a/tipalti/cli/__init__.py
+++ b/tipalti/cli/__init__.py
@@ -16,8 +16,11 @@ import argparse
 import sys
 
 from tipalti import __version__
+from tipalti.cli._commands import bill as _bill_cmd
 from tipalti.cli._commands import explain as _explain_cmd
+from tipalti.cli._commands import invoice as _invoice_cmd
 from tipalti.cli._commands import learn as _learn_cmd
+from tipalti.cli._commands import payee as _payee_cmd
 from tipalti.cli._commands import whoami as _whoami_cmd
 from tipalti.cli._errors import EXIT_USER_ERROR, AfiError
 from tipalti.cli._output import emit_error
@@ -47,9 +50,9 @@ def _build_parser() -> argparse.ArgumentParser:
     _learn_cmd.register(sub)
     _explain_cmd.register(sub)
     _whoami_cmd.register(sub)
-    # Register noun groups here:
-    #   from tipalti.cli._commands import my_noun as _my_noun_group
-    #   _my_noun_group.register(sub)
+    _payee_cmd.register(sub)
+    _invoice_cmd.register(sub)
+    _bill_cmd.register(sub)
 
     return parser
 

--- a/tipalti/cli/_commands/bill.py
+++ b/tipalti/cli/_commands/bill.py
@@ -4,40 +4,20 @@ from __future__ import annotations
 
 import argparse
 
-from tipalti.cli import _listing
-
-_LIST_COLUMNS = ("id", "refCode", "payeeId", "status", "amount")
-
-
-def cmd_list(args: argparse.Namespace) -> int:
-    return _listing.run_list(
-        args,
-        noun="bill",
-        title="bill list",
-        columns=_LIST_COLUMNS,
-        fetch=lambda client: client.bills.list(
-            limit=args.limit, cursor=args.cursor, filter=args.filter
-        ),
-    )
-
-
-def cmd_get(args: argparse.Namespace) -> int:
-    return _listing.run_get(
-        args,
-        noun="bill",
-        fetch=lambda client, rid: client.bills.get(rid),
-    )
+from tipalti.cli._listing import register_noun_group
 
 
 def register(sub: argparse._SubParsersAction) -> None:
-    p = sub.add_parser("bill", help="Tipalti bills (read-only).")
-    verbs = p.add_subparsers(dest="verb")
-    verbs.required = True
-
-    p_list = verbs.add_parser("list", help="List bills.")
-    _listing.add_list_flags(p_list)
-    p_list.set_defaults(func=cmd_list)
-
-    p_get = verbs.add_parser("get", help="Get a single bill by id.")
-    _listing.add_get_flags(p_get, id_help="Bill id.")
-    p_get.set_defaults(func=cmd_get)
+    register_noun_group(
+        sub,
+        noun="bill",
+        group_help="Tipalti bills (read-only).",
+        list_help="List bills.",
+        list_columns=("id", "refCode", "payeeId", "status", "amount"),
+        get_help="Get a single bill by id.",
+        get_id_help="Bill id.",
+        list_fetch=lambda client, args: client.bills.list(
+            limit=args.limit, cursor=args.cursor, filter=args.filter
+        ),
+        get_fetch=lambda client, rid: client.bills.get(rid),
+    )

--- a/tipalti/cli/_commands/bill.py
+++ b/tipalti/cli/_commands/bill.py
@@ -1,0 +1,43 @@
+"""``tipalti bill {list,get}`` — read-only Bills verbs (REST v2)."""
+
+from __future__ import annotations
+
+import argparse
+
+from tipalti.cli import _listing
+
+_LIST_COLUMNS = ("id", "refCode", "payeeId", "status", "amount")
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    return _listing.run_list(
+        args,
+        noun="bill",
+        title="bill list",
+        columns=_LIST_COLUMNS,
+        fetch=lambda client: client.bills.list(
+            limit=args.limit, cursor=args.cursor, filter=args.filter
+        ),
+    )
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    return _listing.run_get(
+        args,
+        noun="bill",
+        fetch=lambda client, rid: client.bills.get(rid),
+    )
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("bill", help="Tipalti bills (read-only).")
+    verbs = p.add_subparsers(dest="verb")
+    verbs.required = True
+
+    p_list = verbs.add_parser("list", help="List bills.")
+    _listing.add_list_flags(p_list)
+    p_list.set_defaults(func=cmd_list)
+
+    p_get = verbs.add_parser("get", help="Get a single bill by id.")
+    _listing.add_get_flags(p_get, id_help="Bill id.")
+    p_get.set_defaults(func=cmd_get)

--- a/tipalti/cli/_commands/invoice.py
+++ b/tipalti/cli/_commands/invoice.py
@@ -4,40 +4,20 @@ from __future__ import annotations
 
 import argparse
 
-from tipalti.cli import _listing
-
-_LIST_COLUMNS = ("id", "refCode", "payeeId", "status", "amount")
-
-
-def cmd_list(args: argparse.Namespace) -> int:
-    return _listing.run_list(
-        args,
-        noun="invoice",
-        title="invoice list",
-        columns=_LIST_COLUMNS,
-        fetch=lambda client: client.invoices.list(
-            limit=args.limit, cursor=args.cursor, filter=args.filter
-        ),
-    )
-
-
-def cmd_get(args: argparse.Namespace) -> int:
-    return _listing.run_get(
-        args,
-        noun="invoice",
-        fetch=lambda client, rid: client.invoices.get(rid),
-    )
+from tipalti.cli._listing import register_noun_group
 
 
 def register(sub: argparse._SubParsersAction) -> None:
-    p = sub.add_parser("invoice", help="Tipalti invoices (read-only).")
-    verbs = p.add_subparsers(dest="verb")
-    verbs.required = True
-
-    p_list = verbs.add_parser("list", help="List invoices.")
-    _listing.add_list_flags(p_list)
-    p_list.set_defaults(func=cmd_list)
-
-    p_get = verbs.add_parser("get", help="Get a single invoice by id.")
-    _listing.add_get_flags(p_get, id_help="Invoice id.")
-    p_get.set_defaults(func=cmd_get)
+    register_noun_group(
+        sub,
+        noun="invoice",
+        group_help="Tipalti invoices (read-only).",
+        list_help="List invoices.",
+        list_columns=("id", "refCode", "payeeId", "status", "amount"),
+        get_help="Get a single invoice by id.",
+        get_id_help="Invoice id.",
+        list_fetch=lambda client, args: client.invoices.list(
+            limit=args.limit, cursor=args.cursor, filter=args.filter
+        ),
+        get_fetch=lambda client, rid: client.invoices.get(rid),
+    )

--- a/tipalti/cli/_commands/invoice.py
+++ b/tipalti/cli/_commands/invoice.py
@@ -1,0 +1,43 @@
+"""``tipalti invoice {list,get}`` — read-only Invoices verbs (REST v2)."""
+
+from __future__ import annotations
+
+import argparse
+
+from tipalti.cli import _listing
+
+_LIST_COLUMNS = ("id", "refCode", "payeeId", "status", "amount")
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    return _listing.run_list(
+        args,
+        noun="invoice",
+        title="invoice list",
+        columns=_LIST_COLUMNS,
+        fetch=lambda client: client.invoices.list(
+            limit=args.limit, cursor=args.cursor, filter=args.filter
+        ),
+    )
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    return _listing.run_get(
+        args,
+        noun="invoice",
+        fetch=lambda client, rid: client.invoices.get(rid),
+    )
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("invoice", help="Tipalti invoices (read-only).")
+    verbs = p.add_subparsers(dest="verb")
+    verbs.required = True
+
+    p_list = verbs.add_parser("list", help="List invoices.")
+    _listing.add_list_flags(p_list)
+    p_list.set_defaults(func=cmd_list)
+
+    p_get = verbs.add_parser("get", help="Get a single invoice by id.")
+    _listing.add_get_flags(p_get, id_help="Invoice id.")
+    p_get.set_defaults(func=cmd_get)

--- a/tipalti/cli/_commands/learn.py
+++ b/tipalti/cli/_commands/learn.py
@@ -99,10 +99,10 @@ def _as_json_payload() -> dict[str, object]:
         ],
         "env_vars": {
             "TIPALTI_CLIENT_ID": "OAuth2 client ID (required)",
-            "TIPALTI_CLIENT_SECRET": "OAuth2 client secret (required)",
+            "TIPALTI_CLIENT_SECRET": "OAuth2 client secret (required)",  # nosec B105
             "TIPALTI_ENV": "sandbox | production (default: sandbox)",
             "TIPALTI_API_BASE": "optional base-URL override",
-            "TIPALTI_TOKEN_URL": "optional token-URL override",
+            "TIPALTI_TOKEN_URL": "optional token-URL override",  # nosec B105
         },
         "list_envelope": {"items": "list of records", "next_cursor": "str | null"},
         "exit_codes": {

--- a/tipalti/cli/_commands/learn.py
+++ b/tipalti/cli/_commands/learn.py
@@ -12,36 +12,71 @@ tipalti — CLI for Tipalti Solutions.
 
 Purpose
 -------
-tipalti is a command-line interface for working with Tipalti Solutions.
-The v0.0.1 surface ships only the agent-first affordances (`learn`,
-`explain`) and an auth-probe stub (`whoami`); domain verbs that talk to
-the Tipalti API land in subsequent releases.
+tipalti is a command-line interface for working with Tipalti Solutions
+through their REST v2 API. v0.1.0 ships a read-only explorer over the
+Payees, Invoices, and Bills resources, plus the agent-first affordances
+(`learn`, `explain`) and a real auth probe (`whoami`).
+
+The first resident user of this CLI is an LLM agent. Every verb supports
+`--json`, exit codes are stable, errors include machine-readable
+remediation hints, and one verb invocation = one upstream HTTP request.
 
 Commands
 --------
   tipalti learn              Print this self-teaching prompt. Supports --json.
   tipalti explain <path>...  Print markdown docs for any noun/verb path.
-                              Supports --json.
-  tipalti whoami             Print the active Tipalti principal. Stub for
-                              now (always reports "unauthenticated") until
-                              real Tipalti API auth is wired. Supports --json.
+                             Supports --json.
+  tipalti whoami             Probe the active Tipalti principal. Supports --json.
+                             Reports `unauthenticated` and exits 0 when no
+                             credentials are configured (probe, not gate).
+
+  tipalti payee list         List payees. Flags: --limit, --cursor, --filter,
+                             --json. One HTTP request per call.
+  tipalti payee get <id>     Fetch a single payee. Supports --json.
+  tipalti invoice list       List invoices. Same flag set as `payee list`.
+  tipalti invoice get <id>   Fetch a single invoice. Supports --json.
+  tipalti bill list          List bills. Same flag set as `payee list`.
+  tipalti bill get <id>      Fetch a single bill. Supports --json.
+
+Authentication (env vars)
+-------------------------
+  TIPALTI_CLIENT_ID, TIPALTI_CLIENT_SECRET   OAuth2 client credentials.
+  TIPALTI_ENV=sandbox|production             Environment (default: sandbox).
+  TIPALTI_API_BASE                           Optional base-URL override.
+  TIPALTI_TOKEN_URL                          Optional token-URL override.
+
+Tokens are cached at $XDG_CACHE_HOME/tipalti/token-<env>.json (mode 0600);
+delete the file to force re-auth.
+
+Pagination & filtering
+----------------------
+List verbs make exactly one HTTP request per invocation. Each response
+carries an envelope `{"items": [...], "next_cursor": str|null}` (in JSON
+mode); in human (markdown) mode, the same continuation token shows up in
+a footer line. There is no `--all` auto-follow flag in this release.
+
+`--filter STR` is forwarded raw as the OData `$filter` query parameter.
+The CLI does no client-side validation; the API rejects bad input.
 
 Machine-readable output
 -----------------------
-Every command that produces a listing or report supports --json. Errors in
+Every command supports --json. Default human mode is markdown (heading +
+key/value list or table) so coder agents can read it cleanly. Errors in
 JSON mode emit {"code", "message", "remediation"} to stderr. Stdout and
 stderr are never mixed.
 
 Exit-code policy
 ----------------
   0 success
-  1 user-input error (bad flag, bad path, missing arg)
-  2 environment / setup error
+  1 user-input error (bad flag, bad path, missing arg, API 4xx)
+  2 environment / setup error (missing env vars, transport failure)
   3+ reserved
 
 More detail
 -----------
   tipalti explain tipalti
+  tipalti explain auth
+  tipalti explain payee
 """
 
 
@@ -49,12 +84,27 @@ def _as_json_payload() -> dict[str, object]:
     return {
         "tool": "tipalti",
         "version": __version__,
-        "purpose": "CLI for Tipalti Solutions.",
+        "purpose": "Read-only CLI explorer for Tipalti REST v2 (Payees, Invoices, Bills).",
+        "primary_consumer": "LLM agent",
         "commands": [
             {"path": ["learn"], "summary": "Self-teaching prompt."},
             {"path": ["explain"], "summary": "Markdown docs by path."},
-            {"path": ["whoami"], "summary": "Auth probe (stub in v0.0.1)."},
+            {"path": ["whoami"], "summary": "Auth probe; exit 0 even when unauth."},
+            {"path": ["payee", "list"], "summary": "List payees."},
+            {"path": ["payee", "get"], "summary": "Get a single payee."},
+            {"path": ["invoice", "list"], "summary": "List invoices."},
+            {"path": ["invoice", "get"], "summary": "Get a single invoice."},
+            {"path": ["bill", "list"], "summary": "List bills."},
+            {"path": ["bill", "get"], "summary": "Get a single bill."},
         ],
+        "env_vars": {
+            "TIPALTI_CLIENT_ID": "OAuth2 client ID (required)",
+            "TIPALTI_CLIENT_SECRET": "OAuth2 client secret (required)",
+            "TIPALTI_ENV": "sandbox | production (default: sandbox)",
+            "TIPALTI_API_BASE": "optional base-URL override",
+            "TIPALTI_TOKEN_URL": "optional token-URL override",
+        },
+        "list_envelope": {"items": "list of records", "next_cursor": "str | null"},
         "exit_codes": {
             "0": "success",
             "1": "user-input error",

--- a/tipalti/cli/_commands/payee.py
+++ b/tipalti/cli/_commands/payee.py
@@ -1,0 +1,43 @@
+"""``tipalti payee {list,get}`` — read-only Payees verbs (REST v2)."""
+
+from __future__ import annotations
+
+import argparse
+
+from tipalti.cli import _listing
+
+_LIST_COLUMNS = ("id", "refCode", "name", "status")
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    return _listing.run_list(
+        args,
+        noun="payee",
+        title="payee list",
+        columns=_LIST_COLUMNS,
+        fetch=lambda client: client.payees.list(
+            limit=args.limit, cursor=args.cursor, filter=args.filter
+        ),
+    )
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    return _listing.run_get(
+        args,
+        noun="payee",
+        fetch=lambda client, rid: client.payees.get(rid),
+    )
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("payee", help="Tipalti payees (read-only).")
+    verbs = p.add_subparsers(dest="verb")
+    verbs.required = True
+
+    p_list = verbs.add_parser("list", help="List payees.")
+    _listing.add_list_flags(p_list)
+    p_list.set_defaults(func=cmd_list)
+
+    p_get = verbs.add_parser("get", help="Get a single payee by id.")
+    _listing.add_get_flags(p_get, id_help="Payee id (or refCode, depending on tenant).")
+    p_get.set_defaults(func=cmd_get)

--- a/tipalti/cli/_commands/payee.py
+++ b/tipalti/cli/_commands/payee.py
@@ -4,40 +4,20 @@ from __future__ import annotations
 
 import argparse
 
-from tipalti.cli import _listing
-
-_LIST_COLUMNS = ("id", "refCode", "name", "status")
-
-
-def cmd_list(args: argparse.Namespace) -> int:
-    return _listing.run_list(
-        args,
-        noun="payee",
-        title="payee list",
-        columns=_LIST_COLUMNS,
-        fetch=lambda client: client.payees.list(
-            limit=args.limit, cursor=args.cursor, filter=args.filter
-        ),
-    )
-
-
-def cmd_get(args: argparse.Namespace) -> int:
-    return _listing.run_get(
-        args,
-        noun="payee",
-        fetch=lambda client, rid: client.payees.get(rid),
-    )
+from tipalti.cli._listing import register_noun_group
 
 
 def register(sub: argparse._SubParsersAction) -> None:
-    p = sub.add_parser("payee", help="Tipalti payees (read-only).")
-    verbs = p.add_subparsers(dest="verb")
-    verbs.required = True
-
-    p_list = verbs.add_parser("list", help="List payees.")
-    _listing.add_list_flags(p_list)
-    p_list.set_defaults(func=cmd_list)
-
-    p_get = verbs.add_parser("get", help="Get a single payee by id.")
-    _listing.add_get_flags(p_get, id_help="Payee id (or refCode, depending on tenant).")
-    p_get.set_defaults(func=cmd_get)
+    register_noun_group(
+        sub,
+        noun="payee",
+        group_help="Tipalti payees (read-only).",
+        list_help="List payees.",
+        list_columns=("id", "refCode", "name", "status"),
+        get_help="Get a single payee by id.",
+        get_id_help="Payee id (or refCode, depending on tenant).",
+        list_fetch=lambda client, args: client.payees.list(
+            limit=args.limit, cursor=args.cursor, filter=args.filter
+        ),
+        get_fetch=lambda client, rid: client.payees.get(rid),
+    )

--- a/tipalti/cli/_commands/whoami.py
+++ b/tipalti/cli/_commands/whoami.py
@@ -1,29 +1,67 @@
-"""``tipalti whoami`` — auth probe stub (Tipalti-specific).
+"""``tipalti whoami`` — auth probe.
 
-Returns ``unauthenticated`` until real Tipalti API auth lands. Supports
-``--json``. Exit code is always ``0`` (probe, not gate).
+Probe, not gate: missing creds and 401 both report ``unauthenticated`` and
+exit 0. Other API/transport errors propagate (`EXIT_ENV_ERROR` / `EXIT_USER_ERROR`).
 """
 
 from __future__ import annotations
 
 import argparse
 
-from tipalti.cli._output import emit_result
+from tipalti.cli._errors import EXIT_ENV_ERROR, AfiError
+from tipalti.cli._output import emit_result, render_kv_md
+
+
+def _emit_unauthenticated(json_mode: bool, env: str | None) -> int:
+    payload = {"status": "unauthenticated", "principal": None, "env": env}
+    if json_mode:
+        emit_result(payload, json_mode=True)
+    else:
+        emit_result(
+            render_kv_md("tipalti whoami", {"status": "unauthenticated", "env": env}),
+            json_mode=False,
+        )
+    return 0
 
 
 def cmd_whoami(args: argparse.Namespace) -> int:
-    payload: dict[str, object] = {"status": "unauthenticated", "principal": None}
-    if getattr(args, "json", False):
-        emit_result(payload, json_mode=True)
-    else:
-        emit_result("unauthenticated", json_mode=False)
+    from tipalti.api import TipaltiClient, load_env
+
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        env = load_env()
+    except AfiError as err:
+        if err.code == EXIT_ENV_ERROR:
+            return _emit_unauthenticated(json_mode, env=None)
+        raise
+
+    with TipaltiClient(env) as client:
+        result = client.whoami()
+
+    if json_mode:
+        emit_result(result, json_mode=True)
+        return 0
+
+    if result["status"] == "unauthenticated":
+        return _emit_unauthenticated(json_mode=False, env=result.get("env"))
+
+    principal = result.get("principal")
+    fields: dict[str, object] = {"status": "authenticated", "env": result.get("env")}
+    if isinstance(principal, dict):
+        for key in ("id", "name", "email", "subject", "sub", "client_id"):
+            value = principal.get(key)
+            if value is not None and key not in fields:
+                fields[key] = value
+    elif principal is not None:
+        fields["principal"] = principal
+    emit_result(render_kv_md("tipalti whoami", fields), json_mode=False)
     return 0
 
 
 def register(sub: argparse._SubParsersAction) -> None:
     p = sub.add_parser(
         "whoami",
-        help="Print the active Tipalti principal (stub in v0.0.1).",
+        help="Print the active Tipalti principal (auth probe; exit 0 even when unauth).",
     )
     p.add_argument("--json", action="store_true", help="Emit structured JSON.")
     p.set_defaults(func=cmd_whoami)

--- a/tipalti/cli/_commands/whoami.py
+++ b/tipalti/cli/_commands/whoami.py
@@ -1,14 +1,15 @@
 """``tipalti whoami`` — auth probe.
 
 Probe, not gate: missing creds and 401 both report ``unauthenticated`` and
-exit 0. Other API/transport errors propagate (`EXIT_ENV_ERROR` / `EXIT_USER_ERROR`).
+exit 0. Other API/transport errors — including unknown ``TIPALTI_ENV`` —
+propagate (`EXIT_ENV_ERROR` / `EXIT_USER_ERROR`).
 """
 
 from __future__ import annotations
 
 import argparse
 
-from tipalti.cli._errors import EXIT_ENV_ERROR, AfiError
+from tipalti.cli._errors import AfiError
 from tipalti.cli._output import emit_result, render_kv_md
 
 
@@ -31,7 +32,7 @@ def cmd_whoami(args: argparse.Namespace) -> int:
     try:
         env = load_env()
     except AfiError as err:
-        if err.code == EXIT_ENV_ERROR:
+        if err.kind == "missing_creds":
             return _emit_unauthenticated(json_mode, env=None)
         raise
 

--- a/tipalti/cli/_errors.py
+++ b/tipalti/cli/_errors.py
@@ -24,18 +24,27 @@ EXIT_ENV_ERROR = 2
 
 @dataclass
 class AfiError(Exception):
-    """Structured error with a remediation hint for agents."""
+    """Structured error with a remediation hint for agents.
+
+    ``kind`` is a free-form discriminator string (e.g. ``"missing_creds"``)
+    that lets handlers distinguish between errors sharing the same exit
+    code without parsing ``message``. Optional; defaults to empty.
+    """
 
     code: int
     message: str
     remediation: str = ""
+    kind: str = ""
 
     def __post_init__(self) -> None:
         super().__init__(self.message)
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "code": self.code,
             "message": self.message,
             "remediation": self.remediation,
         }
+        if self.kind:
+            payload["kind"] = self.kind
+        return payload

--- a/tipalti/cli/_listing.py
+++ b/tipalti/cli/_listing.py
@@ -1,0 +1,88 @@
+"""Shared helpers for the noun-group ``list`` / ``get`` verbs.
+
+Each noun-group module (``payee.py``, ``invoice.py``, ``bill.py``) wires
+its argparse subparsers to handlers in this module. The actual API call
+is supplied as a callable so each noun can target its own resource.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING, Any, Callable, Sequence
+
+from tipalti.cli._output import (
+    emit_result,
+    render_list_md,
+    render_record_md,
+)
+
+if TYPE_CHECKING:
+    from tipalti.api import TipaltiClient
+
+_LIMIT_HELP = "Maximum records to return (default 100, max 500)."
+_CURSOR_HELP = "Continuation token from a previous list response."
+_FILTER_HELP = "Server-side filter, forwarded raw as $filter (e.g. \"status eq 'Active'\")."
+
+
+def add_list_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--limit", type=int, default=100, help=_LIMIT_HELP)
+    parser.add_argument("--cursor", default=None, help=_CURSOR_HELP)
+    parser.add_argument("--filter", dest="filter", default=None, help=_FILTER_HELP)
+    parser.add_argument("--json", action="store_true", help="Emit structured JSON.")
+
+
+def add_get_flags(parser: argparse.ArgumentParser, *, id_help: str) -> None:
+    parser.add_argument("id", help=id_help)
+    parser.add_argument("--json", action="store_true", help="Emit structured JSON.")
+
+
+def run_list(
+    args: argparse.Namespace,
+    *,
+    noun: str,
+    title: str,
+    columns: Sequence[str],
+    fetch: Callable[["TipaltiClient"], dict[str, Any]],
+) -> int:
+    from tipalti.api import TipaltiClient
+
+    json_mode = bool(getattr(args, "json", False))
+    with TipaltiClient.from_env() as client:
+        envelope = fetch(client)
+
+    if json_mode:
+        emit_result(envelope, json_mode=True)
+        return 0
+
+    next_command = f"tipalti {noun} list"
+    markdown = render_list_md(
+        title,
+        envelope.get("items", []),
+        columns,
+        next_cursor=envelope.get("next_cursor"),
+        next_command=next_command,
+    )
+    emit_result(markdown, json_mode=False)
+    return 0
+
+
+def run_get(
+    args: argparse.Namespace,
+    *,
+    noun: str,
+    fetch: Callable[["TipaltiClient", str], Any],
+) -> int:
+    from tipalti.api import TipaltiClient
+
+    json_mode = bool(getattr(args, "json", False))
+    resource_id = args.id
+    with TipaltiClient.from_env() as client:
+        record = fetch(client, resource_id)
+
+    if json_mode:
+        emit_result(record, json_mode=True)
+        return 0
+
+    title = f"{noun} {resource_id}"
+    emit_result(render_record_md(title, record), json_mode=False)
+    return 0

--- a/tipalti/cli/_listing.py
+++ b/tipalti/cli/_listing.py
@@ -86,3 +86,49 @@ def run_get(
     title = f"{noun} {resource_id}"
     emit_result(render_record_md(title, record), json_mode=False)
     return 0
+
+
+def register_noun_group(
+    sub: argparse._SubParsersAction,
+    *,
+    noun: str,
+    group_help: str,
+    list_help: str,
+    list_columns: Sequence[str],
+    get_help: str,
+    get_id_help: str,
+    list_fetch: Callable[["TipaltiClient", argparse.Namespace], dict[str, Any]],
+    get_fetch: Callable[["TipaltiClient", str], Any],
+) -> None:
+    """Register a noun group's ``list`` and ``get`` verbs.
+
+    The noun module supplies just the resource-shaped bits (columns, fetch
+    callables, help strings); this helper owns the argparse boilerplate
+    and the dispatch glue. Keeps each noun module short, makes it
+    impossible to drift the verb surface across nouns.
+    """
+    parser = sub.add_parser(noun, help=group_help)
+    verbs = parser.add_subparsers(dest="verb")
+    verbs.required = True
+
+    list_parser = verbs.add_parser("list", help=list_help)
+    add_list_flags(list_parser)
+
+    def _cmd_list(args: argparse.Namespace) -> int:
+        return run_list(
+            args,
+            noun=noun,
+            title=f"{noun} list",
+            columns=list_columns,
+            fetch=lambda client: list_fetch(client, args),
+        )
+
+    list_parser.set_defaults(func=_cmd_list)
+
+    get_parser = verbs.add_parser("get", help=get_help)
+    add_get_flags(get_parser, id_help=get_id_help)
+
+    def _cmd_get(args: argparse.Namespace) -> int:
+        return run_get(args, noun=noun, fetch=get_fetch)
+
+    get_parser.set_defaults(func=_cmd_get)

--- a/tipalti/cli/_output.py
+++ b/tipalti/cli/_output.py
@@ -3,13 +3,18 @@
 Rule: **results go to stdout, diagnostics and errors go to stderr.** Agents
 parsing output can rely on this invariant. JSON mode routes structured
 payloads to the same streams — never mixes them.
+
+Default human-mode output is markdown (heading + key/value list or table).
+The render helpers (:func:`render_record_md`, :func:`render_list_md`,
+:func:`render_kv_md`) produce strings that are then handed to
+:func:`emit_result` — they don't write directly.
 """
 
 from __future__ import annotations
 
 import json
 import sys
-from typing import Any, TextIO
+from typing import Any, Mapping, Sequence, TextIO
 
 from tipalti.cli._errors import AfiError
 
@@ -51,3 +56,116 @@ def emit_diagnostic(message: str, *, stream: TextIO | None = None) -> None:
     """Write a human diagnostic (progress, summary) to stderr."""
     s = stream if stream is not None else sys.stderr
     s.write(message if message.endswith("\n") else message + "\n")
+
+
+# ---- markdown render helpers ------------------------------------------------
+
+
+def _scalar_md(value: Any) -> str:
+    """Render a scalar for inline use in a markdown bullet."""
+    if value is None:
+        return "_null_"
+    if isinstance(value, bool):
+        return "`true`" if value else "`false`"
+    if isinstance(value, (int, float)):
+        return f"`{value}`"
+    text = str(value)
+    if "\n" in text or len(text) > 80:
+        return "\n\n" + _fenced_json(text) + "\n"
+    return text
+
+
+def _fenced_json(blob: Any) -> str:
+    if isinstance(blob, str):
+        return f"```\n{blob}\n```"
+    return "```json\n" + json.dumps(blob, indent=2, ensure_ascii=False) + "\n```"
+
+
+def render_kv_md(title: str, fields: Mapping[str, Any]) -> str:
+    """Render ``title`` + a flat key/value bullet list. Used by ``whoami``."""
+    lines = [f"# {title}", ""]
+    for key, value in fields.items():
+        lines.append(f"- **{key}:** {_scalar_md(value)}")
+    return "\n".join(lines) + "\n"
+
+
+def render_record_md(title: str, record: Mapping[str, Any] | Any) -> str:
+    """Render a single resource record as markdown.
+
+    Top-level scalar fields → bullet list. Nested objects/arrays → fenced
+    JSON blocks under a sub-heading. Non-mapping records (string, list)
+    are rendered as a single fenced JSON block.
+    """
+    if not isinstance(record, Mapping):
+        return f"# {title}\n\n{_fenced_json(record)}\n"
+
+    scalar_lines: list[str] = []
+    nested: list[tuple[str, Any]] = []
+    for key, value in record.items():
+        if isinstance(value, (Mapping, list)):
+            nested.append((key, value))
+        else:
+            scalar_lines.append(f"- **{key}:** {_scalar_md(value)}")
+
+    parts = [f"# {title}", ""]
+    if scalar_lines:
+        parts.extend(scalar_lines)
+        parts.append("")
+    for key, value in nested:
+        parts.append(f"## {key}")
+        parts.append("")
+        parts.append(_fenced_json(value))
+        parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def render_list_md(
+    title: str,
+    items: Sequence[Mapping[str, Any]],
+    columns: Sequence[str],
+    *,
+    next_cursor: str | None,
+    next_command: str | None = None,
+) -> str:
+    """Render an ``{"items", "next_cursor"}`` list envelope as markdown.
+
+    ``columns`` is the ordered list of field names to project into the
+    table. Missing fields are rendered as an empty cell. Non-scalar values
+    are JSON-encoded inline.
+    """
+    parts = [f"## {title}", ""]
+    if not items:
+        parts.append("_No results._")
+        if next_cursor and next_command:
+            parts.append("")
+            parts.append(f"**Next page:** `{next_command} --cursor={next_cursor}`")
+        return "\n".join(parts) + "\n"
+
+    parts.append("| " + " | ".join(columns) + " |")
+    parts.append("| " + " | ".join(["---"] * len(columns)) + " |")
+    for row in items:
+        cells = [_table_cell(row.get(col) if isinstance(row, Mapping) else None) for col in columns]
+        parts.append("| " + " | ".join(cells) + " |")
+
+    parts.append("")
+    if next_cursor and next_command:
+        parts.append(f"**Next page:** `{next_command} --cursor={next_cursor}`")
+    else:
+        parts.append("_End of results._")
+    return "\n".join(parts) + "\n"
+
+
+def _table_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, (Mapping, list)):
+        encoded = json.dumps(value, ensure_ascii=False)
+        if len(encoded) > 60:
+            encoded = encoded[:57] + "..."
+        return f"`{encoded}`"
+    text = str(value).replace("|", "\\|").replace("\n", " ")
+    return text

--- a/tipalti/explain/catalog.py
+++ b/tipalti/explain/catalog.py
@@ -124,7 +124,7 @@ the Procurement REST surface), set `TIPALTI_API_BASE` and
 ## Token cache
 
 Bearer tokens are cached at `$XDG_CACHE_HOME/tipalti/token-<env>.json`
-(falls back to `~/.cache/tipalti/...`), file mode `0600`. The cache is a
+(falls back to `$HOME/.cache/tipalti/...`), file mode `0600`. The cache is a
 pure performance optimization: delete the file to force re-authentication.
 The cache is automatically invalidated when `TIPALTI_CLIENT_ID` rotates.
 

--- a/tipalti/explain/catalog.py
+++ b/tipalti/explain/catalog.py
@@ -12,22 +12,34 @@ from __future__ import annotations
 _ROOT = """\
 # tipalti
 
-`tipalti` is the command-line interface for Tipalti Solutions. v0.0.1
-ships the agent-first affordances (`learn`, `explain`) and an auth-probe
-stub (`whoami`); domain verbs that exercise the Tipalti API land in later
-releases. The CLI is scaffolded from the AgentCulture sibling pattern.
+`tipalti` is the command-line interface for Tipalti Solutions. v0.1.0
+ships a read-only explorer over Tipalti's REST v2 API (Payees, Invoices,
+Bills) plus the agent-first affordances (`learn`, `explain`, `whoami`).
+
+The CLI is scaffolded from the AgentCulture sibling pattern. Its primary
+consumer is an LLM agent: every verb supports `--json`, errors carry
+machine-readable remediations, and one verb invocation = one upstream
+HTTP request.
 
 ## Verbs
 
 - `tipalti learn` — structured self-teaching prompt.
 - `tipalti explain <path>` — markdown docs for any noun/verb.
-- `tipalti whoami` — auth probe stub (returns `unauthenticated` for now).
+- `tipalti whoami` — auth probe (returns `unauthenticated` and exits 0
+  when no credentials are configured).
+- `tipalti payee list` / `tipalti payee get <id>` — payees (read-only).
+- `tipalti invoice list` / `tipalti invoice get <id>` — invoices.
+- `tipalti bill list` / `tipalti bill get <id>` — bills.
+
+## Authentication
+
+See `tipalti explain auth`.
 
 ## Exit-code policy
 
 - `0` success
-- `1` user-input error
-- `2` environment / setup error
+- `1` user-input error (bad flag, bad path, API 4xx)
+- `2` environment / setup error (missing env vars, transport failure)
 - `3+` reserved
 
 ## See also
@@ -35,13 +47,18 @@ releases. The CLI is scaffolded from the AgentCulture sibling pattern.
 - `tipalti explain learn`
 - `tipalti explain explain`
 - `tipalti explain whoami`
+- `tipalti explain payee`
+- `tipalti explain invoice`
+- `tipalti explain bill`
+- `tipalti explain auth`
 """
 
 _LEARN = """\
 # tipalti learn
 
 Prints a structured self-teaching prompt covering tipalti's purpose,
-command map, exit-code policy, `--json` support, and `explain` pointer.
+command map, env vars, exit-code policy, `--json` support, pagination
+model, and `explain` pointer.
 
 ## Usage
 
@@ -58,24 +75,186 @@ Prints markdown documentation for any noun/verb path. Unlike `--help`
 ## Usage
 
     tipalti explain tipalti
-    tipalti explain learn
+    tipalti explain auth
+    tipalti explain payee
+    tipalti explain payee list
     tipalti explain --json <path>
 """
 
 _WHOAMI = """\
 # tipalti whoami
 
-Auth probe. Reports the active Tipalti principal — or
-`unauthenticated` when no credentials are configured.
+Probes the active Tipalti principal using credentials from the env vars
+documented in `tipalti explain auth`.
 
-In v0.0.1 this is a stub: it always reports `unauthenticated` until real
-Tipalti API authentication lands. Exit code is always `0` (probe, not
-gate).
+When no credentials are configured, when `TIPALTI_CLIENT_ID/SECRET` are
+empty, or when the token endpoint returns 401, `whoami` reports
+`unauthenticated` and exits `0` (probe, not gate). Other API/transport
+errors propagate normally with `EXIT_USER_ERROR` / `EXIT_ENV_ERROR`.
 
 ## Usage
 
     tipalti whoami
     tipalti whoami --json
+"""
+
+_AUTH = """\
+# Authentication
+
+Tipalti REST v2 uses OAuth 2.0 client credentials. The CLI reads:
+
+| Env var                 | Purpose                                   | Required |
+|-------------------------|-------------------------------------------|----------|
+| `TIPALTI_CLIENT_ID`     | OAuth2 client ID                          | yes      |
+| `TIPALTI_CLIENT_SECRET` | OAuth2 client secret                      | yes      |
+| `TIPALTI_ENV`           | `sandbox` \\| `production` (default: sandbox) | no   |
+| `TIPALTI_API_BASE`      | Override the API base URL for the env     | no       |
+| `TIPALTI_TOKEN_URL`     | Override the OAuth2 token URL for the env | no       |
+
+Default URLs:
+
+- Sandbox API:   `https://api.sandbox.tipalti.com`
+- Production API: `https://api.tipalti.com`
+- Token URL: `<API base>/oauth2/token`
+
+If the published Tipalti URLs ever differ from these defaults (e.g. for
+the Procurement REST surface), set `TIPALTI_API_BASE` and
+`TIPALTI_TOKEN_URL` explicitly — no code change needed.
+
+## Token cache
+
+Bearer tokens are cached at `$XDG_CACHE_HOME/tipalti/token-<env>.json`
+(falls back to `~/.cache/tipalti/...`), file mode `0600`. The cache is a
+pure performance optimization: delete the file to force re-authentication.
+The cache is automatically invalidated when `TIPALTI_CLIENT_ID` rotates.
+
+## Diagnostics
+
+    tipalti whoami         # is auth working?
+    tipalti whoami --json  # principal payload
+"""
+
+_PAYEE = """\
+# tipalti payee
+
+Read-only verbs over Tipalti's Payees resource (REST v2).
+
+## Verbs
+
+- `tipalti payee list` — list payees with optional `--filter`, `--limit`,
+  `--cursor`. One HTTP request per call. JSON envelope:
+  `{"items": [...], "next_cursor": str|null}`.
+- `tipalti payee get <id>` — fetch one payee by id.
+
+## Usage
+
+    tipalti payee list --limit 50
+    tipalti payee list --filter "status eq 'Active'"
+    tipalti payee list --cursor <token-from-prior-list>
+    tipalti payee get <id>
+    tipalti payee get <id> --json
+"""
+
+_PAYEE_LIST = """\
+# tipalti payee list
+
+Lists payees from Tipalti REST v2. One HTTP request per invocation.
+
+## Flags
+
+- `--limit N` — max records (default 100, max 500).
+- `--cursor TOKEN` — continuation token from a prior list response.
+- `--filter STR` — server-side filter, forwarded raw as `$filter`.
+- `--json` — emit `{"items": [...], "next_cursor": str|null}`.
+
+## Examples
+
+    tipalti payee list --limit 25
+    tipalti payee list --filter "status eq 'Active'"
+    tipalti payee list --json --filter "country eq 'US'"
+"""
+
+_PAYEE_GET = """\
+# tipalti payee get <id>
+
+Fetches a single payee by id from Tipalti REST v2.
+
+## Flags
+
+- `--json` — emit the raw API record.
+
+## Errors
+
+- `1` `not found: payee <id>` when the API returns 404.
+- `1` `tipalti auth failed` on 401.
+- `2` `cannot reach tipalti: ...` on transport failure.
+"""
+
+_INVOICE = """\
+# tipalti invoice
+
+Read-only verbs over Tipalti's Invoices resource (REST v2).
+
+## Verbs
+
+- `tipalti invoice list` — list invoices with optional `--filter`,
+  `--limit`, `--cursor`.
+- `tipalti invoice get <id>` — fetch one invoice by id.
+
+## Usage
+
+    tipalti invoice list --limit 50
+    tipalti invoice list --filter "status eq 'Approved'"
+    tipalti invoice get <id>
+"""
+
+_INVOICE_LIST = """\
+# tipalti invoice list
+
+Lists invoices from Tipalti REST v2. Same flag set as `tipalti payee list`:
+`--limit`, `--cursor`, `--filter`, `--json`. One HTTP request per call.
+
+## Examples
+
+    tipalti invoice list --filter "status eq 'Approved'"
+    tipalti invoice list --json --limit 200
+"""
+
+_INVOICE_GET = """\
+# tipalti invoice get <id>
+
+Fetches a single invoice by id. `--json` emits the raw API record.
+"""
+
+_BILL = """\
+# tipalti bill
+
+Read-only verbs over Tipalti's Bills resource (REST v2).
+
+## Verbs
+
+- `tipalti bill list` — list bills with optional `--filter`, `--limit`,
+  `--cursor`.
+- `tipalti bill get <id>` — fetch one bill by id.
+
+## Usage
+
+    tipalti bill list --limit 50
+    tipalti bill list --filter "status eq 'Open'"
+    tipalti bill get <id>
+"""
+
+_BILL_LIST = """\
+# tipalti bill list
+
+Lists bills from Tipalti REST v2. Same flag set as `tipalti payee list`:
+`--limit`, `--cursor`, `--filter`, `--json`. One HTTP request per call.
+"""
+
+_BILL_GET = """\
+# tipalti bill get <id>
+
+Fetches a single bill by id. `--json` emits the raw API record.
 """
 
 
@@ -85,4 +264,14 @@ ENTRIES: dict[tuple[str, ...], str] = {
     ("learn",): _LEARN,
     ("explain",): _EXPLAIN,
     ("whoami",): _WHOAMI,
+    ("auth",): _AUTH,
+    ("payee",): _PAYEE,
+    ("payee", "list"): _PAYEE_LIST,
+    ("payee", "get"): _PAYEE_GET,
+    ("invoice",): _INVOICE,
+    ("invoice", "list"): _INVOICE_LIST,
+    ("invoice", "get"): _INVOICE_GET,
+    ("bill",): _BILL,
+    ("bill", "list"): _BILL_LIST,
+    ("bill", "get"): _BILL_GET,
 }

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,19 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "bandit"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -47,6 +60,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
     { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
     { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
 ]
 
 [[package]]
@@ -175,6 +197,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -416,6 +484,18 @@ wheels = [
 ]
 
 [[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -439,8 +519,11 @@ wheels = [
 
 [[package]]
 name = "tipalti"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -451,9 +534,11 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
+    { name = "respx" },
 ]
 
 [package.metadata]
+requires-dist = [{ name = "httpx", specifier = ">=0.27" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -464,4 +549,14 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=4.1" },
     { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "respx", specifier = ">=0.21" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]


### PR DESCRIPTION
## Summary

- First real release on top of the v0.0.1 scaffold: read-only `list`/`get` verbs over Tipalti REST v2 Payees, Invoices, and Bills.
- New `tipalti/api/` subpackage — CLI-agnostic httpx client with OAuth2 client-credentials, on-disk token cache (`$XDG_CACHE_HOME/tipalti/token-<env>.json`, mode 0600), single-retry policy on 429/5xx, and status-code → `AfiError` mapping.
- `tipalti whoami` rewritten from stub to real probe — exits 0 with `unauthenticated` for missing creds and 401.
- Default human-mode output is markdown (agent-friendly); `--json` everywhere; one verb invocation = one upstream HTTP request.
- Env vars: `TIPALTI_CLIENT_ID/SECRET/ENV` + optional `TIPALTI_API_BASE`/`TIPALTI_TOKEN_URL` URL overrides.

Design doc: `/home/spark/.claude/plans/i-want-tipalti-cli-peaceful-crown.md` (local; key sections — Context, Primary consumer: the agent, Verb surface, Module layout, Auth, Pagination & filtering, Output, Error mapping, Retries — captured in `CLAUDE.md` and the new `explain` catalog).

Out of scope (deferred): mutations, `--all` auto-follow, typed filter flags, `tipalti login` / config / keyring, iFrame URL generation, SOAP, webhooks/IPN, tax forms, KYC.

## Test plan

- [x] `uv run pytest -n auto -v` — 77/77 passing (8 new modules + `conftest.py`).
- [x] `uv run flake8 tipalti tests` — clean.
- [x] `uv run black --check tipalti tests` — clean.
- [x] `uv run isort --check tipalti tests` — clean.
- [x] `markdownlint-cli2 "**/*.md"` — clean (excluded `.venv/**`).
- [x] `uv build` — built `tipalti-0.1.0-py3-none-any.whl`.
- [x] `uv run tipalti --version` — `tipalti 0.1.0`.
- [x] `steward doctor . --scope self` — doctor clean (portability + skills 3-rule contract).
- [x] `tipalti whoami` (no creds) — markdown `# tipalti whoami` block, exit 0.
- [x] `tipalti payee list` (no creds) — exit 2, hint to set env vars and read `tipalti explain auth`.
- [x] `tipalti explain auth` / `tipalti explain payee list` — agent-readable markdown.
- [ ] Real-sandbox round trip (`@pytest.mark.integration`) — opt-in, not in CI; documented in `CLAUDE.md`. Requires sandbox credentials.

- Claude