### PR TITLE
docs: clarify tipalti is an unofficial CLI

### DIFF
--- a/.agex/data/pr/events.jsonl
+++ b/.agex/data/pr/events.jsonl
@@ -2,3 +2,6 @@
 {"ts":"2026-05-21T06:42:56.769285+00:00","type":"readiness_arrived","pr":13,"waited_secs":60}
 {"ts":"2026-05-21T06:43:01.347306+00:00","type":"pr_read","pr":13,"comment_count":3,"threads_unresolved":0,"ci_state":"ok"}
 {"ts":"2026-05-21T06:51:00.571531+00:00","type":"pr_read","pr":13,"comment_count":3,"threads_unresolved":0,"ci_state":"ok"}
+{"ts":"2026-05-21T10:55:45.238969+00:00","type":"pr_opened","pr":14,"title":"docs: clarify tipalti is an unofficial CLI"}
+{"ts":"2026-05-21T10:56:48.426212+00:00","type":"readiness_arrived","pr":14,"waited_secs":60}
+{"ts":"2026-05-21T10:56:51.958895+00:00","type":"pr_read","pr":14,"comment_count":3,"threads_unresolved":0,"ci_state":"ok"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Solutions Ltd. Added as a note under the title and an affiliation line in
   the License section. Docs-only; the CLI surface is unchanged.
 
+### Changed
+
+- `pyproject.toml` package `description` now reads "Unofficial CLI for the
+  Tipalti REST API — independent project, not affiliated with Tipalti
+  Solutions Ltd." (was "Tipalti — CLI for Tipalti Solutions."), so the
+  published PyPI metadata matches the README disclaimer instead of
+  presenting as first-party.
+
 ## [0.4.0] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-05-21
+
+### Added
+
+- README disclaimer clarifying that `tipalti` is an unofficial, independent
+  project — not affiliated with, endorsed by, or sponsored by Tipalti
+  Solutions Ltd. Added as a note under the title and an affiliation line in
+  the License section. Docs-only; the CLI surface is unchanged.
+
 ## [0.4.0] - 2026-05-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # tipalti
 
+> **Unofficial.** Independent project, not affiliated with, endorsed by, or
+> sponsored by Tipalti Solutions Ltd. "Tipalti" is a trademark of its
+> respective owner.
+
 CLI for Tipalti Solutions — scaffolded from the AgentCulture sibling pattern.
 Read-only explorer over Tipalti REST v2 (Payees, Invoices, Bills) plus the
 agent-first affordances (`learn`, `explain`, `whoami`).
@@ -77,3 +81,6 @@ canonical templates.
 ## License
 
 MIT — see [`LICENSE`](LICENSE).
+
+Unofficial / independent project. Not affiliated with or endorsed by
+Tipalti Solutions Ltd.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tipalti"
 version = "0.4.1"
-description = "Tipalti — CLI for Tipalti Solutions."
+description = "Unofficial CLI for the Tipalti REST API — independent project, not affiliated with Tipalti Solutions Ltd."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tipalti"
-version = "0.4.0"
+version = "0.4.1"
 description = "Tipalti — CLI for Tipalti Solutions."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ wheels = [
 
 [[package]]
 name = "tipalti"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What

Clarify in the README that `tipalti` is an **unofficial**, independent
project — not affiliated with, endorsed by, or sponsored by Tipalti
Solutions Ltd.

## Changes

- **`README.md`** — "Unofficial" note under the title (incl. trademark
  line) and an affiliation line appended to the License section.
- **`pyproject.toml` / `uv.lock`** — version `0.4.0` → `0.4.1` (mandatory
  `version-check` bump; docs-only otherwise).
- **`CHANGELOG.md`** — `[0.4.1]` entry.

## Why

The package name and "CLI for Tipalti Solutions" tagline read as
first-party. This makes the independent relationship and the trademark
ownership explicit for users and agents.

## Verification

- `markdownlint-cli2 README.md CHANGELOG.md` → 0 errors
- `uv run pytest -n auto` → 121 passed
- `uv run tipalti --version` → `0.4.1`
- `agex pr lint` → no violations

Docs-only; the CLI surface is unchanged.

- tipalti (Claude)
